### PR TITLE
Remove BETA on Download from Odroid C4

### DIFF
--- a/index.html
+++ b/index.html
@@ -1347,7 +1347,7 @@
 				<div id="slidingdiv42" class="toggleDiv single-project">
 					<div class="row">
 						<div class="col-md-12 project-title clearfix">
-							<h3>Odroid C4 (beta)</h3>
+							<h3>Odroid C4</h3>
 							<span class="show_hide close"><i class="fa fa-times"></i></span>
 						</div>
 					</div>


### PR DESCRIPTION
I guess Ordroid C4 Image has reached stable status. At least download is pointing to stable. Therefore I would remove the BETA flag