### PR TITLE
Changed the link "Other device" to Dietpi-docs page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1123,10 +1123,10 @@
 								<div class="project-info">
 									<span>DietPi-PREP:</span>Convert any Debian image, into a DietPi system.
 									<br>
-									<div><a href="https://github.com/MichaIng/DietPi/issues/1285#issue-280771944" target="_blank" rel="noopener"><span>Install Guide:</span> <i class="fa fa-book" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;<u style="font-size:133%;">View</u></a></div>
+									<div><a href="https://dietpi.com/docs/dietpi_sbc/#make-your-own-distribution" target="_blank" rel="noopener"><span>Install Guide:</span> <i class="fa fa-book" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;<u style="font-size:133%;">View</u></a></div>
 								</div>
-								<p>Unable to find an available image for your device? No worries, DietPi can be easily installed on any device!</p>
-								<p>Simply run the DietPi-PREP script in the above link and follow the onscreen instructions.</p>
+								<p>Unable to find an available image for your device? Don’t worry, DietPi contains a script which can be used to turn an installed Debian-based OS into DietPi.</p>
+								<p>Simply follow the instructions.</p>
 								<p><i style="color:grey;font-size: 80%;">NB: End user support will be limited to issues that are DietPi specific (which excludes Kernel/GPU/onboard Bluetooth, WiFi, Audio etc from our support). GPU features are disabled for other devices (e.g.: Kodi, Desktop), ideal for server usage.</i></p>
 							</div>
 						</div>


### PR DESCRIPTION
Link to "Generating your own debian based DietPi image" was linked from the DietPi issues area (issue #1285) to the new description within dietpi.com/docs.  
Text harmonized with text within https://dietpi.com/docs/dietpi_sbc/#make-your-own-distribution. 