### PR TITLE
Update RPi download info

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,19 +246,19 @@
 								<br>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster.7z"><span>32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<li>The ARMv6 32-bit image boots on all Raspberry Pi models and is based on the official Raspberry Pi OS 32-bit image.</li>
+									<div style="display:list-item;list-style-position: inside">The ARMv6 32-bit image boots on all Raspberry Pi models and is based on the official Raspberry Pi OS 32-bit image.</div>
 								</div>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Buster.7z"><span>64-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<li>The ARMv8 64-bit image does <b>NOT</b> boot on Raspberry Pi models 1, Zero or 2 v1.1. A Raspberry Pi with an ARMv8-capable CPU is required. You can find an overview of all Raspberry Pi models and their CPU instruction sets at <a href="https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications" target="_blank" rel="noopener" style="text-decoration-line:underline;">this</a> Wikipedia article.</li>
+									<div style="display:list-item;list-style-position: inside">The ARMv8 64-bit image does <b>NOT</b> boot on Raspberry Pi models 1, Zero or 2 v1.1. A Raspberry Pi with an ARMv8-capable CPU is required. You can find an overview of all Raspberry Pi models and their CPU instruction sets at <a href="https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications" target="_blank" rel="noopener" style="text-decoration-line:underline;">this</a> Wikipedia article.</div>
 								</div>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<li>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.</li>
+									<div style="display:list-item;list-style-position: inside">This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.</div>
 								</div>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Buster_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<li>This image has our <a href="https://dietpi.com/phpbb/viewtopic.php?t=2317" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.</li>
+									<div style="display:list-item;list-style-position: inside">This image has our <a href="https://dietpi.com/phpbb/viewtopic.php?t=2317" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.</div>
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>

--- a/index.html
+++ b/index.html
@@ -244,19 +244,24 @@
 								<div><span>CPU:</span>BCM2835 ARMv6 RPi1 - BCM2711 ARMv8 RPi4</div>
 								<div><span>RAM:</span>256 MiB RPi1 - 8 GiB RPi4</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster.7z"><span>32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Buster.7z"><span>64-bit image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster.7z"><span>32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<li>The ARMv6 32-bit image boots on all Raspberry Pi models and is based on the official Raspberry Pi OS 32-bit image.</li>
+								</div>
+								<div>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Buster.7z"><span>64-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<li>The ARMv8 64-bit image does <b>NOT</b> boot on Raspberry Pi models 1, Zero or 2 v1.1. A Raspberry Pi with an ARMv8-capable CPU is required. You can find an overview of all Raspberry Pi models and their CPU instruction sets at <a href="https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications" target="_blank" rel="noopener" style="text-decoration-line:underline;">this</a> Wikipedia article.</li>
+								</div>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
+									<li>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.</li>
 								</div>
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Buster_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<br>This image has our <a href="https://dietpi.com/phpbb/viewtopic.php?t=2317" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
+									<li>This image has our <a href="https://dietpi.com/phpbb/viewtopic.php?t=2317" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.</li>
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
-							<p>The Raspberry Pi is quite possibly the single SBC that started the IoT era. While the Raspberry Pi may be a few years behind other SBC manufacturers in terms of performance, it's widely available, affordable, has a large community, active kernel development for all models and will always have a place in our hearts.</p>
 						</div>
 						<div class="col-md-6"><img src="images/sbc_images/raspberrypi3.jpg" alt="Raspberry Pi photo" width="8" height="5" loading="lazy"></div>
 					</div>


### PR DESCRIPTION
Clarify on which models the 64-bit image can be used, make the download-specific text a list entry, since it can be a little longer, and remove the obsolete text which refers to the Raspberry Pi 1. Since the multiple downloads for Raspberry Pi already contain quite much text, and since there are multiple models with very different performance features, the general text is not added anymore.

Related issue: https://dietpi.com/phpbb/viewtopic.php?t=9070
I think this is rare, but better to be clear.