### PR TITLE
Update RPi download links to Bullseye images

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,19 +239,26 @@
 								<div><span>RAM:</span>256 MiB RPi1 - 8 GiB RPi4</div>
 								<br>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster.7z"><span>32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<br>The ARMv6 32-bit image boots on all Raspberry Pi models and is based on the official Raspberry Pi OS 32-bit image.
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z"><span>ARMv6 32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<br>Uses the Raspbian package repository and works on <b>ALL</b> Raspberry Pi models. Use this image if unsure!
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Buster.7z"><span>64-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
-									<br>The ARMv8 64-bit image does <b>NOT</b> boot on Raspberry Pi models 1, Zero or 2 v1.1. A Raspberry Pi with an ARMv8-capable CPU is required. You can find an overview of all Raspberry Pi models and their CPU instruction sets at <a href="https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications" target="_blank" rel="noopener" style="text-decoration-line:underline;">this</a> Wikipedia article.
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye.7z"><span>ARMv7 32-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<br>Uses the Debian package repository and does <b>NOT</b> work on Raspberry Pi 1 and Zero models.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Buster_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z"><span>ARMv8 64-bit image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<br>Uses the Debian package repository and does <b>NOT</b> work on Raspberry Pi 1, Zero and 2 v1.1 models.
+								</div>
+								<div>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye_Amiberry.7z"><span>Amiberry ARMv6 image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Buster_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye_Amiberry.7z"><span>Amiberry ARMv7 image:</span><i class="fa fa-download"></i><u>Download</u></a>
+								</div>
+								<div>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye_AlloGUI.7z"><span>Allo GUI ARMv7 image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/phpbb/viewtopic.php?t=2317" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>


### PR DESCRIPTION
and shorten the image description on ARMv6/7/8 to the essential info.