### PR TITLE
Bump Bootstrap to latest v5.1.0

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -33,7 +33,7 @@
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=5">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=1"></script>

--- a/contribute.html
+++ b/contribute.html
@@ -32,11 +32,11 @@
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
-		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
-		<script defer src="js/bootstrap.min.js"></script>
+		<script defer src="js/bootstrap.min.js?v=1"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js"></script>
 	</head>
@@ -45,16 +45,16 @@
 			<div class="container-xl">
 				<img src="images/dietpi-logo_240x80.png" alt="Logo" loading="lazy">
 				<!-- Navigation button, visible on small resolution -->
-				<button class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
+				<button class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
 				<!-- Main navigation -->
 				<div class="navbar-collapse collapse">
-					<a class="nav-link" href="/">Home</a>
-					<a class="nav-link" href="/#features">Features</a>
-					<a class="nav-link" href="/#download">Download</a>
-					<a class="nav-link" href="/#gettingstarted">Getting Started</a>
-					<a class="nav-link" href="stats.html">Stats</a>
-					<a class="nav-link" href="#contribute">Contribute</a>
-					<a class="nav-link" href="/#testimonials">Testimonials</a>
+					<a class="nav-link" href="/">HOME</a>
+					<a class="nav-link" href="/#features">FEATURES</a>
+					<a class="nav-link" href="/#download">DOWNLOAD</a>
+					<a class="nav-link" href="/#gettingstarted">GETTING STARTED</a>
+					<a class="nav-link" href="stats.html">STATS</a>
+					<a class="nav-link" href="#contribute">CONTRIBUTE</a>
+					<a class="nav-link" href="/#testimonials">TESTIMONIALS</a>
 				</div>
 				<!-- End main navigation -->
 			</div>

--- a/css/style.css
+++ b/css/style.css
@@ -2,11 +2,12 @@
 
  * Table of content
 1 General: Base style and bootstrap overrides.
+ 1.1 Navigation bar
+ 1.2 Filter buttons
 2 Layout
- 2.1 Animations
- 2.2 Buttons
- 2.3 Thumbnail: Override bootstrap thumbnail and add hover effect
- 2.4 Icons
+ 2.1 Buttons
+ 2.2 Thumbnail: Override bootstrap thumbnail and add hover effect
+ 2.3 Icons
 3 Sections: Definition for sections and subsections
  3.1 Features
  3.2 Details frame
@@ -33,12 +34,20 @@ p {
 	color: #ffffff;
 }
 a {
+	text-decoration-line: none;
 	color: #ffffff;
 }
-a:hover {
+a:hover,
+a:focus,
+a:active {
 	color: #c5ff00;
-	text-decoration-line: none;
 }
+.container-xl {
+	max-width: 1140px;
+}
+/*
+1.1 Navigation bar
+**********************************************************************/
 .navbar {
 	position: fixed;
 	top: 0;
@@ -68,6 +77,7 @@ a:hover {
 	stroke-width: 2;
 	stroke-linecap: round;
 	fill: none;
+	box-shadow: none;
 	transition: background-color 0.5s, border-color 0.5s, stroke 0.5s;
 }
 @media (max-width: 991px) {
@@ -88,8 +98,6 @@ a:hover {
 }
 .navbar > .container-xl > .navbar-collapse > a {
 	color: #ffffff;
-	background-color: #164046;
-	text-transform: uppercase;
 	font-size: 15px;
 	margin: 4.5px 0;
 	padding: 10px 14px;
@@ -103,6 +111,9 @@ a:hover {
 .navbar > .container-xl > .navbar-collapse > a.active {
 	border-color: #c5ff00;
 }
+/*
+1.2 Filter buttons
+**********************************************************************/
 .nav.nav-pills {
 	margin-bottom: 30px;
 }
@@ -153,7 +164,7 @@ a:hover {
 	transform: scaleY(1);
 }
 /*
-2.2 Buttons
+2.1 Buttons
 **********************************************************************/
 .button {
 	display: inline-block;
@@ -183,18 +194,14 @@ a:hover {
 	background-color: unset;
 }
 /*
-2.3 Thumbnails
+2.2 Thumbnails
 **********************************************************************/
-#portfolio-grid {
-	margin-left: -5px;
-}
 .thumbnail {
 	display: block;
 	overflow: hidden;
 	position: relative;
 	padding: 4px;
 	margin-bottom: 20px;
-	margin-left: -10px;
 	text-align: center;
 	background-color: #164046;
 	border-radius: 4px;
@@ -255,7 +262,7 @@ a:hover {
 	transform: translateY(-100%);
 }
 /*
-2.4 Icons
+2.3 Icons
 **********************************************************************/
 .fa-download {
 	content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path fill='white' d='M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 8-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z'/></svg>");
@@ -316,12 +323,19 @@ a:hover {
 	border-radius: 50%;
 	transition: transform 0.25s;
 }
-.service svg:hover {
+.service > a:hover > svg,
+.service > a:focus > svg,
+.service > a:active > svg {
 	transform: scale(1.1, 1.1);
 	border-color: #c5ff00;
 }
 .service h3 {
 	margin-top: 10px;
+}
+.service > a:hover > h3,
+.service > a:focus > h3,
+.service > a:active > h3 {
+	color: #c5ff00;
 }
 .service p {
 	padding: 0 10px;
@@ -349,7 +363,14 @@ a:hover {
 	height: 50px;
 	padding: 10px;
 	cursor: pointer;
+	float: right;
 	content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 5'><path fill='none' stroke='white' stroke-width='1' stroke-linecap='round' d='M1 1l3 3M1 4l3-3'/></svg>");
+	opacity: 0.5;
+}
+.project-title .close:hover,
+.project-title .close:focus,
+.project-title .close:active {
+	opacity: 0.75;
 }
 .project-description {
 	font-size: 14px;

--- a/css/style.css
+++ b/css/style.css
@@ -383,6 +383,8 @@ a:active {
 }
 .project-info {
 	padding: 10px 20px;
+	/* Vertical scroll bar when content is too wide */
+	overflow-x: auto;
 }
 .project-info div {
 	margin-bottom: 5px;
@@ -410,6 +412,22 @@ a:active {
 	/* "height: auto" in combination with inline width and height allows to keep aspect ratio while loading for non-bleeding edge browsers, which do not support "aspect-ratio" yet. */
 	height: auto;
 	padding: 15px;
+}
+.project-info > table {
+	width: 100%;
+	white-space: nowrap;
+}
+.project-info > table th,
+.project-info > table td {
+	border: 1px solid #9ccc00;
+	padding: 5px;
+}
+.project-info > table td > code,
+.project-info > table td.los {
+	color: #ff7799;
+}
+.project-info > table td.win {
+	color: #c5ff00;
 }
 /*
 3.3 Testimonials

--- a/deploy.bash
+++ b/deploy.bash
@@ -51,9 +51,9 @@ G_EXEC sed -i "s|<lastmod>.*</lastmod>|<lastmod>$(date '+%Y-%m-%dT%T%:z')</lastm
 
 # 3rd party
 G_EXEC curl -sSfL 'https://raw.githubusercontent.com/jquery/codeorigin.jquery.com/main/cdn/jquery-3.6.0.min.js' -o js/jquery.js
-G_EXEC curl -sSfL 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css' -o css/bootstrap.css
+G_EXEC curl -sSfL 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css' -o css/bootstrap.css
 G_EXEC sed -i '\|^/\*# sourceMappingURL=bootstrap.min.css.map \*/$|d' css/bootstrap.css # Suppress browser console warning about missing map file
-G_EXEC curl -sSfL 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js' -o js/bootstrap.js
+G_EXEC curl -sSfL 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.min.js' -o js/bootstrap.js
 G_EXEC sed -i '\|^//# sourceMappingURL=bootstrap.min.js.map$|d' js/bootstrap.js # Suppress browser console warning about missing map file
 G_EXEC curl -sSfL 'https://raw.githubusercontent.com/MichaIng/mixitup/patch-1/dist/mixitup.js' -o js/mixitup.js
 

--- a/dietpi-software.html
+++ b/dietpi-software.html
@@ -33,7 +33,7 @@
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=5">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=1"></script>

--- a/dietpi-software.html
+++ b/dietpi-software.html
@@ -32,11 +32,11 @@
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
-		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
-		<script defer src="js/bootstrap.min.js"></script>
+		<script defer src="js/bootstrap.min.js?v=1"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js"></script>
 	</head>
@@ -45,16 +45,16 @@
 			<div class="container-xl">
 				<img src="images/dietpi-logo_240x80.png" alt="Logo" loading="lazy">
 				<!-- Navigation button, visible on small resolution -->
-				<button class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
+				<button class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
 				<!-- Main navigation -->
 				<div class="navbar-collapse collapse">
-					<a class="nav-link" href="/">Home</a>
-					<a class="nav-link" href="/#features">Features</a>
-					<a class="nav-link" href="/#download">Download</a>
-					<a class="nav-link" href="/#gettingstarted">Getting Started</a>
-					<a class="nav-link" href="stats.html">Stats</a>
-					<a class="nav-link" href="contribute.html">Contribute</a>
-					<a class="nav-link" href="/#testimonials">Testimonials</a>
+					<a class="nav-link" href="/">HOME</a>
+					<a class="nav-link" href="/#features">FEATURES</a>
+					<a class="nav-link" href="/#download">DOWNLOAD</a>
+					<a class="nav-link" href="/#gettingstarted">GETTING STARTED</a>
+					<a class="nav-link" href="stats.html">STATS</a>
+					<a class="nav-link" href="contribute.html">CONTRIBUTE</a>
+					<a class="nav-link" href="/#testimonials">TESTIMONIALS</a>
 				</div>
 				<!-- End main navigation -->
 			</div>

--- a/index.html
+++ b/index.html
@@ -32,12 +32,12 @@
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
-		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
 		<link rel="stylesheet" type="text/css" href="css/jquery.cslider.min.css?v=3">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
-		<script defer src="js/bootstrap.min.js"></script>
+		<script defer src="js/bootstrap.min.js?v=1"></script>
 		<script defer src="js/jquery.cslider.min.js?v=1"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js"></script>
@@ -47,16 +47,16 @@
 			<div class="container-xl">
 				<img src="images/dietpi-logo_240x80.png" alt="DietPi logo" loading="lazy">
 				<!-- Navigation button, visible on small resolution -->
-				<button class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
+				<button class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
 				<!-- Main navigation -->
 				<div class="navbar-collapse collapse">
-					<a class="nav-link" href="#home">Home</a>
-					<a class="nav-link" href="#features">Features</a>
-					<a class="nav-link" href="#download">Download</a>
-					<a class="nav-link" href="#gettingstarted">Getting Started</a>
-					<a class="nav-link" href="stats.html">Stats</a>
-					<a class="nav-link" href="contribute.html">Contribute</a>
-					<a class="nav-link" href="#testimonials">Testimonials</a>
+					<a class="nav-link" href="#home">HOME</a>
+					<a class="nav-link" href="#features">FEATURES</a>
+					<a class="nav-link" href="#download">DOWNLOAD</a>
+					<a class="nav-link" href="#gettingstarted">GETTING STARTED</a>
+					<a class="nav-link" href="stats.html">STATS</a>
+					<a class="nav-link" href="contribute.html">CONTRIBUTE</a>
+					<a class="nav-link" href="#testimonials">TESTIMONIALS</a>
 				</div>
 				<!-- End main navigation -->
 			</div>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
 		<link rel="stylesheet" type="text/css" href="css/jquery.cslider.min.css?v=3">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=5">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=1"></script>

--- a/stats.html
+++ b/stats.html
@@ -32,15 +32,8 @@
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
-		<style>
-			.project-info { overflow-x: auto; }
-			table { width: 100%; white-space: nowrap; }
-			th,td { border: 1px solid #9ccc00; padding: 5px; }
-			td>code, td.los { color: #ff7799; }
-			td.win { color: #c5ff00; }
-		</style>
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=5">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=1"></script>

--- a/stats.html
+++ b/stats.html
@@ -39,11 +39,11 @@
 			td>code, td.los { color: #ff7799; }
 			td.win { color: #c5ff00; }
 		</style>
-		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=1">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=4">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
-		<script defer src="js/bootstrap.min.js"></script>
+		<script defer src="js/bootstrap.min.js?v=1"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js"></script>
 	</head>
@@ -52,16 +52,16 @@
 			<div class="container-xl">
 				<img src="images/dietpi-logo_240x80.png" alt="Logo" loading="lazy">
 				<!-- Navigation button, visible on small resolution -->
-				<button class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
+				<button class="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"><svg viewBox="0 0 12 12"><path d="M1 1h10M1 6h10M1 11h10"/></svg></button>
 				<!-- Main navigation -->
 				<div class="navbar-collapse collapse">
-					<a class="nav-link" href="/">Home</a>
-					<a class="nav-link" href="/#features">Features</a>
-					<a class="nav-link" href="/#download">Download</a>
-					<a class="nav-link" href="/#gettingstarted">Getting Started</a>
-					<a class="nav-link" href="#stats">Stats</a>
-					<a class="nav-link" href="contribute.html">Contribute</a>
-					<a class="nav-link" href="/#testimonials">Testimonials</a>
+					<a class="nav-link" href="/">HOME</a>
+					<a class="nav-link" href="/#features">FEATURES</a>
+					<a class="nav-link" href="/#download">DOWNLOAD</a>
+					<a class="nav-link" href="/#gettingstarted">GETTING STARTED</a>
+					<a class="nav-link" href="#stats">STATS</a>
+					<a class="nav-link" href="contribute.html">CONTRIBUTE</a>
+					<a class="nav-link" href="/#testimonials">TESTIMONIALS</a>
 				</div>
 				<!-- End main navigation -->
 			</div>


### PR DESCRIPTION
This does not officially support IE anymore, i.e. probably some CSS/JS rules/functions are used which IE does not understand, while the website as a whole will still be functional, of course.

EDIT: Okay, IE was broken before, due to `NodeList.forEach()` in JavaScript, `#aabbccdd` colour codes. `text-decoration-line` CSS and `url(data:image/xml+svg,...)` inline SVG background images. As we're not going to waste time fixing this, there is even less reason to further defer Bootstrap v5 🙂.