### PR TITLE
Remove most jQuery usage

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -33,12 +33,12 @@
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=6">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
-		<script defer src="js/app.min.js"></script>
+		<script defer src="js/app.min.js?v=1"></script>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-lg">
@@ -94,7 +94,7 @@
 					<button class="nav-link filter" data-filter=".Expand">Expand code / documentation</button>
 				</nav>
 				<!-- Bug report -->
-				<div id="bugreport" class="toggleDiv single-project">
+				<div id="bugreport" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Create a new bug report / Report a security issue</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -108,7 +108,7 @@
 					</div>
 				</div>
 				<!-- Diagnose -->
-				<div id="diagnose" class="toggleDiv single-project">
+				<div id="diagnose" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Investigate issues / Provide help</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -129,7 +129,7 @@
 					</div>
 				</div>
 				<!-- Question -->
-				<div id="question" class="toggleDiv single-project">
+				<div id="question" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Answer questions / Provide insights</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -140,7 +140,7 @@
 					</div>
 				</div>
 				<!-- Test -->
-				<div id="test" class="toggleDiv single-project">
+				<div id="test" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Test configurations</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -157,7 +157,7 @@
 					</div>
 				</div>
 				<!-- Improve website -->
-				<div id="improvewebsite" class="toggleDiv single-project">
+				<div id="improvewebsite" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Improve DietPi website</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -169,7 +169,7 @@
 					</div>
 				</div>
 				<!-- Improve docs -->
-				<div id="improvedocs" class="toggleDiv single-project">
+				<div id="improvedocs" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Expand DietPi Docs</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -180,7 +180,7 @@
 					</div>
 				</div>
 				<!-- Suggest -->
-				<div id="suggest" class="toggleDiv single-project">
+				<div id="suggest" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>New feature suggestions & Software titles</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -194,7 +194,7 @@
 					</div>
 				</div>
 				<!-- Code -->
-				<div id="code" class="toggleDiv single-project">
+				<div id="code" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Extend DietPi</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -213,7 +213,7 @@
 					</div>
 				</div>
 				<!-- Community -->
-				<div id="community" class="toggleDiv single-project">
+				<div id="community" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Use DietPi Forum</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -228,7 +228,7 @@
 					</div>
 				</div>
 				<!-- Blog -->
-				<div id="blog" class="toggleDiv single-project">
+				<div id="blog" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Write about DietPi</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -242,7 +242,7 @@
 					</div>
 				</div>
 				<!-- Social -->
-				<div id="social" class="toggleDiv single-project">
+				<div id="social" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Social media</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -366,7 +366,7 @@
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.toggleDiv').forEach(function(e){e.setAttribute("style","display:none");});
+			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
 			document.getElementById("contributeinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/css/style.css
+++ b/css/style.css
@@ -519,7 +519,7 @@ a.scrollup {
 	stroke-width: 2;
 	stroke-linecap: round;
 	fill: none;
-	transition: background-color 0.5s, border-color 0.5s, stroke 0.5s;
+	transition: background-color 0.5s, border-color 0.5s, stroke 0.5s, opacity 0.5s;
 }
 a.scrollup:hover,
 a.scrollup:focus,

--- a/dietpi-software.html
+++ b/dietpi-software.html
@@ -33,12 +33,12 @@
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=6">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
-		<script defer src="js/app.min.js"></script>
+		<script defer src="js/app.min.js?v=1"></script>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-lg">
@@ -94,7 +94,7 @@
 					<button class="nav-link filter" data-filter=".Misc">Misc</button>
 				</nav>
 				<!-- Start details for portfolio project 1 -->
-				<div id="slidingdiv1" class="toggleDiv row single-project">
+				<div id="slidingdiv1" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/lxde_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/lxde_1.jpg" alt="LXDE" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -120,7 +120,7 @@
 				</div>
 				<!-- End details for portfolio project 1 -->
 				<!-- Start details for portfolio project 2 -->
-				<div id="slidingdiv2" class="toggleDiv row single-project">
+				<div id="slidingdiv2" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/mate_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/mate_1.jpg" alt="MATE" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -145,7 +145,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 3 -->
-				<div id="slidingdiv3" class="toggleDiv row single-project">
+				<div id="slidingdiv3" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/xfce_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/xfce_1.jpg" alt="Xfce" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -170,7 +170,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 4 -->
-				<div id="slidingdiv4" class="toggleDiv row single-project">
+				<div id="slidingdiv4" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/gnustep_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/gnustep_1.jpg" alt="GNUstep" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -195,7 +195,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 5 -->
-				<div id="slidingdiv5" class="toggleDiv row single-project">
+				<div id="slidingdiv5" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/chromium_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/chromium_1.jpg" alt="Chromium" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -226,7 +226,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 6 -->
-				<div id="slidingdiv6" class="toggleDiv row single-project">
+				<div id="slidingdiv6" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/vnc_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/vnc_1.jpg" alt="VNC Server" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -245,7 +245,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 7 -->
-				<div id="slidingdiv7" class="toggleDiv row single-project">
+				<div id="slidingdiv7" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nomachine_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nomachine_1.jpg" alt="NoMachine" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -265,7 +265,7 @@
 				</div>
 				<!-- End details for portfolio project 7 -->
 				<!-- Start details for portfolio project 8 -->
-				<div id="slidingdiv8" class="toggleDiv row single-project">
+				<div id="slidingdiv8" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/vnc_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/vnc_1.jpg" alt="XRDP" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -284,7 +284,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 9 -->
-				<div id="slidingdiv9" class="toggleDiv row single-project">
+				<div id="slidingdiv9" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/vnc_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/vnc_1.jpg" alt="RealVNC" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -304,7 +304,7 @@
 				</div>
 				<!-- End details for portfolio project 9 -->
 				<!-- Start details for portfolio project 10 -->
-				<div id="slidingdiv10" class="toggleDiv row single-project">
+				<div id="slidingdiv10" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/kodi_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/kodi_1.jpg" alt="Kodi" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -323,7 +323,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 11 -->
-				<div id="slidingdiv11" class="toggleDiv row single-project">
+				<div id="slidingdiv11" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/ympd_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/ympd_1.jpg" alt="ympd" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -343,7 +343,7 @@
 				</div>
 				<!-- End details for portfolio project 11 -->
 				<!-- Start details for portfolio project 12 -->
-				<div id="slidingdiv12" class="toggleDiv row single-project">
+				<div id="slidingdiv12" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/ompd_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/ompd_1.jpg" alt="O!MPD" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -363,7 +363,7 @@
 				</div>
 				<!-- End details for portfolio project 12 -->
 				<!-- Start details for portfolio project 13 -->
-				<div id="slidingdiv13" class="toggleDiv row single-project">
+				<div id="slidingdiv13" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/cava_1.gif" target="_blank" rel="noopener"><img src="images/dietpi-software/cava_1.gif" alt="CAVA" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -382,7 +382,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 14 -->
-				<div id="slidingdiv14" class="toggleDiv row single-project">
+				<div id="slidingdiv14" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/mopidy_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/mopidy_1.jpg" alt="Mopidy" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -401,7 +401,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 15 -->
-				<div id="slidingdiv15" class="toggleDiv row single-project">
+				<div id="slidingdiv15" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/airsonic_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/airsonic_1.jpg" alt="Airsonic" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -421,7 +421,7 @@
 				</div>
 				<!-- End details for portfolio project 15 -->
 				<!-- Start details for portfolio project 17 -->
-				<div id="slidingdiv17" class="toggleDiv row single-project">
+				<div id="slidingdiv17" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/squeezebox_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/squeezebox_1.jpg" alt="Logitech Media Server" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -442,7 +442,7 @@
 				</div>
 				<!-- End details for portfolio project 17 -->
 				<!-- Start details for portfolio project 18 -->
-				<div id="slidingdiv18" class="toggleDiv row single-project">
+				<div id="slidingdiv18" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/readymedia_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/readymedia_1.jpg" alt="ReadyMedia" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -462,7 +462,7 @@
 				</div>
 				<!-- End details for portfolio project 18 -->
 				<!-- Start details for portfolio project 19 -->
-				<div id="slidingdiv19" class="toggleDiv row single-project">
+				<div id="slidingdiv19" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/shairportsync_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/shairportsync_1.jpg" alt="Shairport Sync" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -482,7 +482,7 @@
 				</div>
 				<!-- End details for portfolio project 19 -->
 				<!-- Start details for portfolio project 20 -->
-				<div id="slidingdiv20" class="toggleDiv row single-project">
+				<div id="slidingdiv20" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/ampache_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/ampache_1.jpg" alt="Ampache" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -502,7 +502,7 @@
 				</div>
 				<!-- End details for portfolio project 20 -->
 				<!-- Start details for portfolio project 21 -->
-				<div id="slidingdiv21" class="toggleDiv row single-project">
+				<div id="slidingdiv21" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/emby_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/emby_1.jpg" alt="Emby" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -522,7 +522,7 @@
 				</div>
 				<!-- End details for portfolio project 21 -->
 				<!-- Start details for portfolio project 22 -->
-				<div id="slidingdiv22" class="toggleDiv row single-project">
+				<div id="slidingdiv22" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/plex_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/plex_1.jpg" alt="Plex" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -542,7 +542,7 @@
 				</div>
 				<!-- End details for portfolio project 22 -->
 				<!-- Start details for portfolio project 22 -->
-				<div id="slidingdiv23" class="toggleDiv row single-project">
+				<div id="slidingdiv23" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/plexpy_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/plexpy_1.jpg" alt="Tautulli" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -562,7 +562,7 @@
 				</div>
 				<!-- End details for portfolio project 23 -->
 				<!-- Start details for portfolio project 24 -->
-				<div id="slidingdiv24" class="toggleDiv row single-project">
+				<div id="slidingdiv24" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/mumble_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/mumble_0.jpg" alt="Murmur" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -582,7 +582,7 @@
 				</div>
 				<!-- End details for portfolio project 24 -->
 				<!-- Start details for portfolio project 25 -->
-				<div id="slidingdiv25" class="toggleDiv row single-project">
+				<div id="slidingdiv25" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/roon_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/roon_1.jpg" alt="Roon Bridge" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -602,7 +602,7 @@
 				</div>
 				<!-- End details for portfolio project 25 -->
 				<!-- Start details for portfolio project 26 -->
-				<div id="slidingdiv26" class="toggleDiv row single-project">
+				<div id="slidingdiv26" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/roon_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/roon_1.jpg" alt="Roon Server" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -622,7 +622,7 @@
 				</div>
 				<!-- End details for portfolio project 26 -->
 				<!-- Start details for portfolio project 27 -->
-				<div id="slidingdiv27" class="toggleDiv row single-project">
+				<div id="slidingdiv27" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/naa_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/naa_1.jpg" alt="NAA Daemon" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -642,7 +642,7 @@
 				</div>
 				<!-- End details for portfolio project 27 -->
 				<!-- Start details for portfolio project 28 -->
-				<div id="slidingdiv28" class="toggleDiv row single-project">
+				<div id="slidingdiv28" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/icecast_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/icecast_1.jpg" alt="IceCast" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -662,7 +662,7 @@
 				</div>
 				<!-- End details for portfolio project 28 -->
 				<!-- Start details for portfolio project 29 -->
-				<div id="slidingdiv29" class="toggleDiv row single-project">
+				<div id="slidingdiv29" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/koel_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/koel_1.jpg" alt="Koel" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -682,7 +682,7 @@
 				</div>
 				<!-- End details for portfolio project 29 -->
 				<!-- Start details for portfolio project 30 -->
-				<div id="slidingdiv30" class="toggleDiv row single-project">
+				<div id="slidingdiv30" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/gmrender_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/gmrender_0.jpg" alt="GMediaRender" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -702,7 +702,7 @@
 				</div>
 				<!-- End details for portfolio project 30 -->
 				<!-- Start details for portfolio project 31 -->
-				<div id="slidingdiv31" class="toggleDiv row single-project">
+				<div id="slidingdiv31" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/transmission_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/transmission_1.jpg" alt="Transmission" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -722,7 +722,7 @@
 				</div>
 				<!-- End details for portfolio project 31 -->
 				<!-- Start details for portfolio project 32 -->
-				<div id="slidingdiv32" class="toggleDiv row single-project">
+				<div id="slidingdiv32" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/deluge_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/deluge_1.jpg" alt="Deluge" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -742,7 +742,7 @@
 				</div>
 				<!-- End details for portfolio project 32 -->
 				<!-- Start details for portfolio project 33 -->
-				<div id="slidingdiv33" class="toggleDiv row single-project">
+				<div id="slidingdiv33" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/qbittorrent_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/qbittorrent_1.jpg" alt="qBittorrent" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -762,7 +762,7 @@
 				</div>
 				<!-- End details for portfolio project 33 -->
 				<!-- Start details for portfolio project 34 -->
-				<div id="slidingdiv34" class="toggleDiv row single-project">
+				<div id="slidingdiv34" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/rtorrent_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/rtorrent_1.jpg" alt="rTorrent" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -782,7 +782,7 @@
 				</div>
 				<!-- End details for portfolio project 34 -->
 				<!-- Start details for portfolio project 35 -->
-				<div id="slidingdiv35" class="toggleDiv row single-project">
+				<div id="slidingdiv35" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/aria2_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/aria2_1.jpg" alt="Aria2" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -803,7 +803,7 @@
 				</div>
 				<!-- End details for portfolio project 35 -->
 				<!-- Start details for portfolio project 36 -->
-				<div id="slidingdiv36" class="toggleDiv row single-project">
+				<div id="slidingdiv36" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/sabnzbd_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/sabnzbd_1.jpg" alt="SABnzbd" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -824,7 +824,7 @@
 				</div>
 				<!-- End details for portfolio project 36 -->
 				<!-- Start details for portfolio project 37 -->
-				<div id="slidingdiv37" class="toggleDiv row single-project">
+				<div id="slidingdiv37" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/medusa_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/medusa_1.jpg" alt="Medusa" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -844,7 +844,7 @@
 				</div>
 				<!-- End details for portfolio project 37 -->
 				<!-- Start details for portfolio project 38 -->
-				<div id="slidingdiv38" class="toggleDiv row single-project">
+				<div id="slidingdiv38" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/sonarr_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/sonarr_1.jpg" alt="Sonarr" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -864,7 +864,7 @@
 				</div>
 				<!-- End details for portfolio project 38 -->
 				<!-- Start details for portfolio project 39 -->
-				<div id="slidingdiv39" class="toggleDiv row single-project">
+				<div id="slidingdiv39" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/radarr_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/radarr_1.jpg" alt="Radarr" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -884,7 +884,7 @@
 				</div>
 				<!-- End details for portfolio project 39 -->
 				<!-- Start details for portfolio project 41 -->
-				<div id="slidingdiv41" class="toggleDiv row single-project">
+				<div id="slidingdiv41" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/jackett_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/jackett_1.jpg" alt="Jackett" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -904,7 +904,7 @@
 				</div>
 				<!-- End details for portfolio project 41 -->
 				<!-- Start details for portfolio project 42 -->
-				<div id="slidingdiv42" class="toggleDiv row single-project">
+				<div id="slidingdiv42" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nzbget_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nzbget_1.jpg" alt="NZBGet" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -924,7 +924,7 @@
 				</div>
 				<!-- End details for portfolio project 42 -->
 				<!-- Start details for portfolio project 43 -->
-				<div id="slidingdiv43" class="toggleDiv row single-project">
+				<div id="slidingdiv43" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/htpcmanager_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/htpcmanager_1.jpg" alt="HTPC Manager" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -944,7 +944,7 @@
 				</div>
 				<!-- End details for portfolio project 43 -->
 				<!-- Start details for portfolio project 44 -->
-				<div id="slidingdiv44" class="toggleDiv row single-project">
+				<div id="slidingdiv44" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/opentyrian_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/opentyrian_1.jpg" alt="OpenTyrian screenshot" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -963,7 +963,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 45 -->
-				<div id="slidingdiv45" class="toggleDiv row single-project">
+				<div id="slidingdiv45" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/cuberite_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/cuberite_1.jpg" alt="Cuberite" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -982,7 +982,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 46 -->
-				<div id="slidingdiv46" class="toggleDiv row single-project">
+				<div id="slidingdiv46" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/mineos_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/mineos_1.jpg" alt="MineOS" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1001,7 +1001,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 47 -->
-				<div id="slidingdiv47" class="toggleDiv row single-project">
+				<div id="slidingdiv47" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nukkit_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nukkit_1.jpg" alt="Nukkit" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1020,7 +1020,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 48 -->
-				<div id="slidingdiv48" class="toggleDiv row single-project">
+				<div id="slidingdiv48" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/amiberry_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/amiberry_1.jpg" alt="Amiberry" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1039,7 +1039,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 49 -->
-				<div id="slidingdiv49" class="toggleDiv row single-project">
+				<div id="slidingdiv49" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/dxxrebirth_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/dxxrebirth_1.jpg" alt="DXX-Rebirth" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1058,7 +1058,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 50 -->
-				<div id="slidingdiv50" class="toggleDiv row single-project">
+				<div id="slidingdiv50" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/steam_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/steam_1.jpg" alt="Steam" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1077,7 +1077,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 51 -->
-				<div id="slidingdiv51" class="toggleDiv row single-project">
+				<div id="slidingdiv51" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/rpicamcontrol_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/rpicamcontrol_1.jpg" alt="RPi Cam Control" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1096,7 +1096,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 52 -->
-				<div id="slidingdiv52" class="toggleDiv row single-project">
+				<div id="slidingdiv52" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/motioneye_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/motioneye_1.jpg" alt="MotionEye" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1115,7 +1115,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 53 -->
-				<div id="slidingdiv53" class="toggleDiv row single-project">
+				<div id="slidingdiv53" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/owncloud_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/owncloud_1.jpg" alt="ownCloud" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1134,7 +1134,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 54 -->
-				<div id="slidingdiv54" class="toggleDiv row single-project">
+				<div id="slidingdiv54" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nextcloud_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nextcloud_1.jpg" alt="Nextcloud" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1153,7 +1153,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 55 -->
-				<div id="slidingdiv55" class="toggleDiv row single-project">
+				<div id="slidingdiv55" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/pydio_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/pydio_1.jpg" alt="Pydio" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1172,7 +1172,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 56 -->
-				<div id="slidingdiv56" class="toggleDiv row single-project">
+				<div id="slidingdiv56" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/urbackupserver_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/urbackupserver_1.jpg" alt="UrBackup" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1191,7 +1191,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 57 -->
-				<div id="slidingdiv57" class="toggleDiv row single-project">
+				<div id="slidingdiv57" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/gogs_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/gogs_1.jpg" alt="Gogs" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1210,7 +1210,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 58 -->
-				<div id="slidingdiv58" class="toggleDiv row single-project">
+				<div id="slidingdiv58" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/gitea_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/gitea_1.jpg" alt="Gitea" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1229,7 +1229,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 59 -->
-				<div id="slidingdiv59" class="toggleDiv row single-project">
+				<div id="slidingdiv59" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/syncthing_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/syncthing_1.jpg" alt="Syncthing" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1248,7 +1248,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 61 -->
-				<div id="slidingdiv61" class="toggleDiv row single-project">
+				<div id="slidingdiv61" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/minio_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/minio_0.jpg" alt="MinIO" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1267,7 +1267,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 62 -->
-				<div id="slidingdiv62" class="toggleDiv row single-project">
+				<div id="slidingdiv62" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/phpbb3_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/phpbb3_1.jpg" alt="phpBB" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1286,7 +1286,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 63 -->
-				<div id="slidingdiv63" class="toggleDiv row single-project">
+				<div id="slidingdiv63" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/wordpress_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/wordpress_1.jpg" alt="Wordpress" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1305,7 +1305,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 64 -->
-				<div id="slidingdiv64" class="toggleDiv row single-project">
+				<div id="slidingdiv64" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/imageallery_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/imageallery_1.jpg" alt="Single File PHP Gallery" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1324,7 +1324,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 65 -->
-				<div id="slidingdiv65" class="toggleDiv row single-project">
+				<div id="slidingdiv65" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/baikal_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/baikal_1.jpg" alt="Baïkal" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1343,7 +1343,7 @@
 					</div>
 				</div>
 				<!-- Start details for portfolio project 66 -->
-				<div id="slidingdiv66" class="toggleDiv row single-project">
+				<div id="slidingdiv66" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/openbazaar_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/openbazaar_1.jpg" alt="OpenBazaar" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1363,7 +1363,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 67 -->
-				<div id="slidingdiv67" class="toggleDiv row single-project">
+				<div id="slidingdiv67" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/yacy_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/yacy_1.jpg" alt="YaCy" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1382,7 +1382,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 68 -->
-				<div id="slidingdiv68" class="toggleDiv row single-project">
+				<div id="slidingdiv68" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/wifihotspot_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/wifihotspot_0.jpg" alt="WiFi HotSpot" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1401,7 +1401,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 69 -->
-				<div id="slidingdiv69" class="toggleDiv row single-project">
+				<div id="slidingdiv69" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/torwifihotspot_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/torwifihotspot_1.jpg" alt="Tor WiFi logo" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1420,7 +1420,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 70 -->
-				<div id="slidingdiv70" class="toggleDiv row single-project">
+				<div id="slidingdiv70" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Home Assistant" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1439,7 +1439,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 71 -->
-				<div id="slidingdiv71" class="toggleDiv row single-project">
+				<div id="slidingdiv71" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Google AIY" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1458,7 +1458,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 72 -->
-				<div id="slidingdiv72" class="toggleDiv row single-project">
+				<div id="slidingdiv72" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/pijuice_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/pijuice_0.jpg" alt="PiJuice" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1477,7 +1477,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 73 -->
-				<div id="slidingdiv73" class="toggleDiv row single-project">
+				<div id="slidingdiv73" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/rpigpio_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/rpigpio_0.jpg" alt="RPi.GPIO" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1496,7 +1496,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 74 -->
-				<div id="slidingdiv74" class="toggleDiv row single-project">
+				<div id="slidingdiv74" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/rpigpio_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/rpigpio_0.jpg" alt="WiringPi" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1515,7 +1515,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 75 -->
-				<div id="slidingdiv75" class="toggleDiv row single-project">
+				<div id="slidingdiv75" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="WebIOPi" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1534,7 +1534,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 76 -->
-				<div id="slidingdiv76" class="toggleDiv row single-project">
+				<div id="slidingdiv76" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Node-RED" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1553,7 +1553,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 77 -->
-				<div id="slidingdiv77" class="toggleDiv row single-project">
+				<div id="slidingdiv77" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Mosquitto" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1572,7 +1572,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 78 -->
-				<div id="slidingdiv78" class="toggleDiv row single-project">
+				<div id="slidingdiv78" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Blynk" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1591,7 +1591,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 79 -->
-				<div id="slidingdiv79" class="toggleDiv row single-project">
+				<div id="slidingdiv79" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/pispc_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/pispc_0.jpg" alt="Audiophonics Pi-SPC" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1610,7 +1610,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 80 -->
-				<div id="slidingdiv80" class="toggleDiv row single-project">
+				<div id="slidingdiv80" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/influxdb_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/influxdb_0.jpg" alt="InfluxDB" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1630,7 +1630,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 81 -->
-				<div id="slidingdiv81" class="toggleDiv row single-project">
+				<div id="slidingdiv81" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/grafana_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/grafana_1.jpg" alt="Grafana" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1650,7 +1650,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 82 -->
-				<div id="slidingdiv82" class="toggleDiv row single-project">
+				<div id="slidingdiv82" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Remot3.it" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1669,7 +1669,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 83 -->
-				<div id="slidingdiv83" class="toggleDiv row single-project">
+				<div id="slidingdiv83" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="VirtualHere" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1688,7 +1688,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 84 -->
-				<div id="slidingdiv84" class="toggleDiv row single-project">
+				<div id="slidingdiv84" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/dietpi-cloudshell_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/dietpi-cloudshell_1.jpg" alt="DietPi-CloudShell" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1707,7 +1707,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 85 -->
-				<div id="slidingdiv85" class="toggleDiv row single-project">
+				<div id="slidingdiv85" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Linux Dash" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1726,7 +1726,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 86 -->
-				<div id="slidingdiv86" class="toggleDiv row single-project">
+				<div id="slidingdiv86" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="phpSysInfo" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1745,7 +1745,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 87 -->
-				<div id="slidingdiv87" class="toggleDiv row single-project">
+				<div id="slidingdiv87" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="RPi Monitor" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1764,7 +1764,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 88 -->
-				<div id="slidingdiv88" class="toggleDiv row single-project">
+				<div id="slidingdiv88" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/netdata_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/netdata_1.jpg" alt="Netdata" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1783,7 +1783,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 89 -->
-				<div id="slidingdiv89" class="toggleDiv row single-project">
+				<div id="slidingdiv89" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Webmin" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1802,7 +1802,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 90 -->
-				<div id="slidingdiv90" class="toggleDiv row single-project">
+				<div id="slidingdiv90" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/fail2ban_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/fail2ban_0.jpg" alt="Fail2Ban" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1821,7 +1821,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 91 -->
-				<div id="slidingdiv91" class="toggleDiv row single-project">
+				<div id="slidingdiv91" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/apache2_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/apache2_0.jpg" alt="Apache2" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1841,7 +1841,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 92 -->
-				<div id="slidingdiv92" class="toggleDiv row single-project">
+				<div id="slidingdiv92" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nginx_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nginx_0.jpg" alt="Nginx" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1861,7 +1861,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 93 -->
-				<div id="slidingdiv93" class="toggleDiv row single-project">
+				<div id="slidingdiv93" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/lighttpd_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/lighttpd_0.jpg" alt="Lighttpd" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1881,7 +1881,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 94 -->
-				<div id="slidingdiv94" class="toggleDiv row single-project">
+				<div id="slidingdiv94" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="phpMyAdmin" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1897,7 +1897,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 95 -->
-				<div id="slidingdiv95" class="toggleDiv row single-project">
+				<div id="slidingdiv95" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/certbot_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/certbot_0.jpg" alt="Certbot" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1916,7 +1916,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 96 -->
-				<div id="slidingdiv96" class="toggleDiv row single-project">
+				<div id="slidingdiv96" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/noimage_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/noimage_1.jpg" alt="Tomcat" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1932,7 +1932,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 97 -->
-				<div id="slidingdiv97" class="toggleDiv row single-project">
+				<div id="slidingdiv97" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/pihole_1.png" target="_blank" rel="noopener"><img src="images/dietpi-software/pihole_1.png" alt="Pi-hole" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1951,7 +1951,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 98 -->
-				<div id="slidingdiv98" class="toggleDiv row single-project">
+				<div id="slidingdiv98" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/proftp_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/proftp_0.jpg" alt="ProFTPD" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1970,7 +1970,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 99 -->
-				<div id="slidingdiv99" class="toggleDiv row single-project">
+				<div id="slidingdiv99" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/samba_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/samba_0.jpg" alt="Samba Server" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -1989,7 +1989,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 100 -->
-				<div id="slidingdiv100" class="toggleDiv row single-project">
+				<div id="slidingdiv100" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/vsftpd_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/vsftpd_0.jpg" alt="vsftpd" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2008,7 +2008,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 101 -->
-				<div id="slidingdiv101" class="toggleDiv row single-project">
+				<div id="slidingdiv101" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/nfs_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/nfs_0.jpg" alt="NFS" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2027,7 +2027,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 102 -->
-				<div id="slidingdiv102" class="toggleDiv row single-project">
+				<div id="slidingdiv102" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/openvpn_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/openvpn_0.jpg" alt="OpenVPN" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2046,7 +2046,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 103 -->
-				<div id="slidingdiv103" class="toggleDiv row single-project">
+				<div id="slidingdiv103" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/pivpn_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/pivpn_0.jpg" alt="PiVPN" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2065,7 +2065,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 105 -->
-				<div id="slidingdiv105" class="toggleDiv row single-project">
+				<div id="slidingdiv105" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/octoprint_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/octoprint_1.jpg" alt="OctoPrint" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2084,7 +2084,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 106 -->
-				<div id="slidingdiv106" class="toggleDiv row single-project">
+				<div id="slidingdiv106" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/haproxy_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/haproxy_1.jpg" alt="HAProxy" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2103,7 +2103,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 108 -->
-				<div id="slidingdiv108" class="toggleDiv row single-project">
+				<div id="slidingdiv108" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/dropbear_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/dropbear_0.jpg" alt="Dropbear" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2122,7 +2122,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 109 -->
-				<div id="slidingdiv109" class="toggleDiv row single-project">
+				<div id="slidingdiv109" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/opensshserver_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/opensshserver_0.jpg" alt="OpenSSH Server" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2141,7 +2141,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 110 -->
-				<div id="slidingdiv110" class="toggleDiv row single-project">
+				<div id="slidingdiv110" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/dietpiramlog_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/dietpiramlog_0.jpg" alt="DietPi-RAMlog" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2160,7 +2160,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 111 -->
-				<div id="slidingdiv111" class="toggleDiv row single-project">
+				<div id="slidingdiv111" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/fulllogging_0.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/fulllogging_0.jpg" alt="Full Logging" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2179,7 +2179,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 112 -->
-				<div id="slidingdiv112" class="toggleDiv row single-project">
+				<div id="slidingdiv112" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/roon_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/roon_1.jpg" alt="Roon Extension Manager" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2198,7 +2198,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 113 -->
-				<div id="slidingdiv113" class="toggleDiv row single-project">
+				<div id="slidingdiv113" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/ubooquity_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/ubooquity_1.jpg" alt="Ubooquity" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2217,7 +2217,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 114 -->
-				<div id="slidingdiv114" class="toggleDiv row single-project">
+				<div id="slidingdiv114" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/lidarr_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/lidarr_1.jpg" alt="Lidarr" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2236,7 +2236,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 115 -->
-				<div id="slidingdiv115" class="toggleDiv row single-project">
+				<div id="slidingdiv115" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/foldingathome_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/foldingathome_1.jpg" alt="Folding@Home" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2255,7 +2255,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 116 -->
-				<div id="slidingdiv116" class="toggleDiv row single-project">
+				<div id="slidingdiv116" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/freshrss_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/freshrss_1.jpg" alt="FreshRSS" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2274,7 +2274,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 117 -->
-				<div id="slidingdiv117" class="toggleDiv row single-project">
+				<div id="slidingdiv117" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/mympd_1.gif" target="_blank" rel="noopener"><img src="images/dietpi-software/mympd_1.gif" alt="myMPD" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -2293,7 +2293,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 				</div>
 				<!-- Start details for portfolio project 119 -->
-				<div id="slidingdiv119" class="toggleDiv row single-project">
+				<div id="slidingdiv119" class="row single-project">
 					<div class="col-md-4"><a href="images/dietpi-software/lxqt_1.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/lxqt_2.jpg" alt="LXQt" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
@@ -3147,7 +3147,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.toggleDiv').forEach(function(e){e.setAttribute("style","display:none");});
+			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
 			document.getElementById("softwareinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/index.html
+++ b/index.html
@@ -34,13 +34,13 @@
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
 		<link rel="stylesheet" type="text/css" href="css/jquery.cslider.min.css?v=3">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=6">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/jquery.cslider.min.js?v=1"></script>
 		<script defer src="js/mixitup.min.js"></script>
-		<script defer src="js/app.min.js"></script>
+		<script defer src="js/app.min.js?v=1"></script>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-lg">
@@ -223,7 +223,7 @@
 					<button class="nav-link filter" data-filter=".x86_64">PC/VM</button>
 					<button class="nav-link filter" data-filter=".other">Other</button>
 				</nav>
-				<div id="raspberrypi1" class="toggleDiv single-project">
+				<div id="raspberrypi1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 1/Zero (1)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -247,7 +247,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/raspberrypi1.jpg" alt="Raspberry Pi 1 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="raspberrypi2" class="toggleDiv single-project">
+				<div id="raspberrypi2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2 PCB v1.1</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -274,7 +274,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/raspberrypi2.jpg" alt="Raspberry Pi 2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="raspberrypi4" class="toggleDiv single-project">
+				<div id="raspberrypi4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2/3/4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -301,7 +301,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/raspberrypi4.jpg" alt="Raspberry Pi 4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="odroidc1" class="toggleDiv single-project">
+				<div id="odroidc1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C1</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -321,7 +321,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/odroidc1.jpg" alt="Odroid C1 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="odroidc2" class="toggleDiv single-project">
+				<div id="odroidc2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -337,7 +337,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/odroidc2.jpg" alt="Odroid C2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="odroidxu3" class="toggleDiv single-project">
+				<div id="odroidxu3" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Odroid XU3/XU4/MC1/HC1/HC2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -353,7 +353,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/odroidxu4.jpg" alt="Odroid XU4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="pinea64" class="toggleDiv single-project">
+				<div id="pinea64" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>PINE A64</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -370,7 +370,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/pinea64.jpg" alt="PINE A64 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineo" class="toggleDiv single-project">
+				<div id="nanopineo" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -387,7 +387,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineo.jpg" alt="NanoPi NEO photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineoair" class="toggleDiv single-project">
+				<div id="nanopineoair" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Air</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -405,7 +405,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineoair.jpg" alt="NanoPi NEO Air photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim1" class="toggleDiv single-project">
+				<div id="nanopim1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -422,7 +422,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim1.jpg" alt="NanoPi M1 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim2" class="toggleDiv single-project">
+				<div id="nanopim2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M2/T2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -439,7 +439,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim2.jpg" alt="NanoPi M2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim3" class="toggleDiv single-project">
+				<div id="nanopim3" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M3/T3</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -456,7 +456,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim3.jpg" alt="NanoPi M3 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="pinebook" class="toggleDiv single-project">
+				<div id="pinebook" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -475,7 +475,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/pinebook.jpg" alt="Pinebook photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="hyperv" class="toggleDiv single-project">
+				<div id="hyperv" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Hyper-V</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -490,7 +490,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/hyperv.jpg" alt="Hyper-V logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="parallels" class="toggleDiv single-project">
+				<div id="parallels" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Parallels</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -505,7 +505,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/parallels.svg" alt="Parallels logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="utm" class="toggleDiv single-project">
+				<div id="utm" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>UTM</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -520,7 +520,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/utm.png" alt="UTM logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="proxmox" class="toggleDiv single-project">
+				<div id="proxmox" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Proxmox</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -535,7 +535,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/proxmox.svg" alt="Proxmox logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="odroidn2" class="toggleDiv single-project">
+				<div id="odroidn2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Odroid N2(+)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -553,7 +553,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/odroidn2.jpg" alt="Odroid N2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="vmware" class="toggleDiv single-project">
+				<div id="vmware" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>VMware/ESXi</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -575,7 +575,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/vmware.jpg" alt="VMware logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="virtualbox" class="toggleDiv single-project">
+				<div id="virtualbox" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>VirtualBox</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -590,7 +590,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/virtualbox.jpg" alt="VirtualBox logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="rockpi4" class="toggleDiv single-project">
+				<div id="rockpi4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi 4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -608,7 +608,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/rockpi4.jpg" alt="ROCK Pi 4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="zeropi" class="toggleDiv single-project">
+				<div id="zeropi" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ZeroPi</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -624,7 +624,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/zeropi.jpg" alt="ZeroPi photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="sparkysbc" class="toggleDiv single-project">
+				<div id="sparkysbc" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Sparky SBC (Allo)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -646,7 +646,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/sparkysbc.jpg" alt="Sparky SBC photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="asustinkerboard" class="toggleDiv single-project">
+				<div id="asustinkerboard" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ASUS Tinker Board</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -664,7 +664,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/asustinkerboard.jpg" alt="ASUS Tinker Board photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopifire3" class="toggleDiv single-project">
+				<div id="nanopifire3" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi Fire3</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -681,7 +681,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopifire3.jpg" alt="NanoPi Fire3 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim1plus" class="toggleDiv single-project">
+				<div id="nanopim1plus" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1 Plus</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -699,7 +699,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim1plus.jpg" alt="NanoPi M1 Plus photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineo2" class="toggleDiv single-project">
+				<div id="nanopineo2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -716,7 +716,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineo2.jpg" alt="NanoPi NEO2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopik1plus" class="toggleDiv single-project">
+				<div id="nanopik1plus" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K1 Plus</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -733,7 +733,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopik1plus.jpg" alt="NanoPi K1 Plus photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineo2black" class="toggleDiv single-project">
+				<div id="nanopineo2black" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2 Black</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -751,7 +751,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineo2black.jpg" alt="NanoPi NEO2 Black photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim4v2" class="toggleDiv single-project">
+				<div id="nanopim4v2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4V2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -769,7 +769,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim4v2.jpg" alt="NanoPi M4V2" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="pineh64" class="toggleDiv single-project">
+				<div id="pineh64" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>PINE H64</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -787,7 +787,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/pineh64.jpg" alt="PINE H64 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="rockpro64" class="toggleDiv single-project">
+				<div id="rockpro64" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCKPro64</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -805,7 +805,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/rockpro64.jpg" alt="ROCKPro64 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="quartz64a" class="toggleDiv single-project">
+				<div id="quartz64a" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model A</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -823,7 +823,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/quartz64a.jpg" alt="Quartz64 Model A photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="quartz64b" class="toggleDiv single-project">
+				<div id="quartz64b" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model B</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -841,7 +841,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/quartz64b.jpg" alt="Quartz64 Model B photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="soquartz" class="toggleDiv single-project">
+				<div id="soquartz" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>SOQuartz</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -859,7 +859,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/soquartz.jpg" alt="SOQuartz photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nativepcbios" class="toggleDiv single-project">
+				<div id="nativepcbios" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for BIOS/CSM</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -879,7 +879,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nativepc.jpg" alt="PC logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="rock64" class="toggleDiv single-project">
+				<div id="rock64" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCK64</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -898,7 +898,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/rock64.jpg" alt="ROCK64 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nativepcuefi" class="toggleDiv single-project">
+				<div id="nativepcuefi" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for UEFI</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -914,7 +914,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nativepc.jpg" alt="PC logo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="otherdevice" class="toggleDiv single-project">
+				<div id="otherdevice" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Other device (beta)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -930,7 +930,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/otherdevice.jpg" alt="Question mark" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopct4" class="toggleDiv single-project">
+				<div id="nanopct4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPC T4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -948,7 +948,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopct4.jpg" alt="NanoPC T4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="rockpis" class="toggleDiv single-project">
+				<div id="rockpis" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi S</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -966,7 +966,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/rockpis.jpg" alt="ROCK Pi S photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineoplus2" class="toggleDiv single-project">
+				<div id="nanopineoplus2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Plus2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -983,7 +983,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineoplus2.jpg" alt="NanoPi NEO Plus2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopim4" class="toggleDiv single-project">
+				<div id="nanopim4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1001,7 +1001,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopim4.jpg" alt="NanoPi M4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineo4" class="toggleDiv single-project">
+				<div id="nanopineo4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1019,7 +1019,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineo4.jpg" alt="NanoPi NEO4 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopineo3" class="toggleDiv single-project">
+				<div id="nanopineo3" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO3</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1037,7 +1037,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopineo3.jpg" alt="NanoPi NEO3 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopir2s" class="toggleDiv single-project">
+				<div id="nanopir2s" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R2S</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1055,7 +1055,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopir2s.jpg" alt="NanoPi R2S photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="nanopik2" class="toggleDiv single-project">
+				<div id="nanopik2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K2</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1073,7 +1073,7 @@
 						<div class="col-md-6"><img src="images/sbc_images/nanopik2.jpg" alt="NanoPi K2 photo" width="8" height="5" loading="lazy"></div>
 					</div>
 				</div>
-				<div id="odroidc4" class="toggleDiv single-project">
+				<div id="odroidc4" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C4/HC4</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1092,7 +1092,7 @@
 					</div>
 				</div>
 				<!-- NanoPi R4S -->
-				<div id="nanopir4s" class="toggleDiv single-project">
+				<div id="nanopir4s" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R4S</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1110,7 +1110,7 @@
 					</div>
 				</div>
 				<!-- NanoPi R5S/R5C -->
-				<div id="nanopir5s" class="toggleDiv single-project">
+				<div id="nanopir5s" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R5S/R5C</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1129,7 +1129,7 @@
 					</div>
 				</div>
 				<!-- NanoPi R6S -->
-				<div id="nanopir6s" class="toggleDiv single-project">
+				<div id="nanopir6s" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R6S</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1149,7 +1149,7 @@
 					</div>
 				</div>
 				<!-- Pinebook Pro -->
-				<div id="pinebookpro" class="toggleDiv single-project">
+				<div id="pinebookpro" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook Pro</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1168,7 +1168,7 @@
 					</div>
 				</div>
 				<!-- NanoPi R1 -->
-				<div id="nanopir1" class="toggleDiv single-project">
+				<div id="nanopir1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R1</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1187,7 +1187,7 @@
 					</div>
 				</div>
 				<!-- Radxa Zero -->
-				<div id="radxazero" class="toggleDiv single-project">
+				<div id="radxazero" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Radxa Zero</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1210,7 +1210,7 @@
 					</div>
 				</div>
 				<!-- ROCK 3A -->
-				<div id="rock3a" class="toggleDiv single-project">
+				<div id="rock3a" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 3A</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1230,7 +1230,7 @@
 					</div>
 				</div>
 				<!-- ROCK 5B -->
-				<div id="rock5b" class="toggleDiv single-project">
+				<div id="rock5b" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 5B</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
@@ -1767,7 +1767,7 @@
 		<a class="scrollup" href="#"><svg viewBox="0 0 12 12"><path d="M1 8l5-5l5 5"/></svg></a>
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.toggleDiv').forEach(function(e){e.setAttribute("style","display:none");});
+			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
 			document.getElementById("downloadinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,63 +1,70 @@
-'use strict';
 // https://github.com/MichaIng/DietPi-Website
-$(function () {
+'use strict';
+!function () {
 	// Initialise home slider: https://github.com/Le-Stagiaire/jquery.cslider
 	// Check first if function exist to allow skipping it on dietpi-software site
-	if (typeof $.fn.cslider === 'function') {
+	if (typeof $.fn.cslider === 'function')
 		$('#home').cslider();
-	}
 
-	// Map navigation bar scroll links and targets
+	// Store used elements globally once
 	var lastId,
-	    $navbar = $('div.navbar-collapse'),
-	    navbarHeight = 60, // $navbar.outerHeight() leads to wrong scroll offset when menu is expanded
+	    scrollUp = document.querySelector('a.scrollup'),
+	    triangles = document.querySelectorAll('svg.triangle'),
+	    singleProjects = document.querySelectorAll('div.single-project'),
+	    navbar = document.querySelector('div.navbar-collapse'),
+	    navbarHeight = 60, // navbar.outerHeight() leads to wrong scroll offset when menu is expanded
 	    // Navigation bar links
-	    $navbarLinks = $navbar.find('a[href^="#"]'),
+	    navbarLinks = navbar.querySelectorAll('a[href^="#"]'),
 	    // Navigation bar targets
-	    $navbarTargets = $navbarLinks.map(function () {
-		return $(this.hash);
-	    });
+	    navbarTargets = [];
+	    for (let x of navbarLinks) {
+		navbarTargets.push(document.getElementById(x.hash.substring(1)));
+	    }
 
 	// Bind to scroll
-	$(window).on('scroll', function () {
-		// Get current scroll offset
-		var scrollTop = $(this).scrollTop();
-
+	window.addEventListener('scroll', function () {
 		// Mark navbar link, related to scroll position, as active
-		// - Get targets until current scroll position
-		var cur = $navbarTargets.map(function () {
-			if ($(this).offset().top < scrollTop + navbarHeight + 50)
-				return this;
-		});
-		// - Get id of the current target
-		cur = cur[cur.length - 1];
-		var id = cur && cur.length ? cur[0].id : '';
-		// - If id changed, change links active class accordingly
-		if (lastId !== id) {
-			lastId = id;
-			$navbarLinks.removeClass('active');
-			$navbarLinks.filter('[href="#' + id + '"]').addClass('active');
+		// - Get ID of the current target
+		var curId = '';
+		for (let x of navbarTargets) {
+			if (x.getBoundingClientRect().y > navbarHeight + 50)
+				break;
+			curId = x.id;
+		}
+
+		// - If ID changed, change links active class accordingly
+		if (lastId !== curId) {
+			lastId = curId;
+			for (let x of navbarLinks) {
+				if (x.hash === '#' + curId) {
+					x.classList.add('active');
+				} else {
+					x.classList.remove('active');
+				}
+			}
 		}
 
 		// Animate triangles once, when they come in view
-		$('svg.triangle').each(function () {
-			// Element has not been animated yet and is in view
-			if (!$(this).hasClass('fadeInDown') && (scrollTop + $(window).innerHeight() > $(this).offset().top) && (scrollTop < $(this).offset().top + $(this).outerHeight())) {
+		for (let x of triangles) {
+			// Break once loop reached triangle below viewport
+			if (x.getBoundingClientRect().y > window.innerHeight)
+				break;
+			// Triangle is in view and has not been animated yet
+			if (x.getBoundingClientRect().bottom > 0 && !x.classList.contains('fadeInDown'))
 				// Add animate classes
-				$(this).addClass('fadeInDown');
-			}
-		});
+				x.classList.add('fadeInDown');
+		}
 
-		// Display or hide scroll to top button
-		if (scrollTop > 80) {
-			$('a.scrollup').fadeIn();
+		// Display or hide scroll-to-top button
+		if (window.pageYOffset > 80) {
+			scrollUp.style.opacity = 100;
 		} else {
-			$('a.scrollup').fadeOut();
+			scrollUp.style.opacity = 0;
 		}
 	});
 
 	// Trigger scroll event once to set initial element states
-	$(window).trigger('scroll');
+	window.dispatchEvent(new Event('scroll'));
 
 	// Initialise MixItUp for animated portfolio tile filtering
 	mixitup('div.mixitup', {
@@ -65,33 +72,37 @@ $(function () {
 		callbacks: {
 			// Close open portfolio project when resorting
 			'onMixStart': function () {
-				$('div.toggleDiv').hide();
+				for (let x of singleProjects) {
+					x.style.display = 'none';
+				}
 			}
 		}
 	});
 
 	// Show or hide portfolio description on click
-	$('.show_hide').on('click', function () {
-		$('div.toggleDiv').slideUp(500, '');
-		$($(this).attr('rel')).slideToggle(500, '');
-	});
+	for (let x of document.querySelectorAll('.show_hide')) {
+		x.addEventListener('click', function () {
+			$('div.single-project').slideUp(500, '');
+			$(x.getAttribute('rel')).slideToggle(500, '');
+		});
+	}
 
 	// Function for smooth scrolling links
-	$('a[href^="#"]').each(function () {
+	for (let x of document.querySelectorAll('a[href^="#"]')) {
 		// Scroll to top offset
-		var targetOffset;
-		if (this.hash === '') {
+		let target, targetOffset;
+		if (x.hash === '') {
 			targetOffset = 0;
 		// Scroll target
 		} else {
-			var $target = $(this.hash);
+			target = document.getElementById(x.hash.substring(1));
 		}
-		$(this).on('click', function () {
- 			// Collapse navbar when scrolling
-			$navbar.removeClass('show');
+		x.addEventListener('click', function () {
+			// Collapse navbar when scrolling
+			navbar.classList.remove('show');
 			// Get section offset
-			if (targetOffset !== 0)
-				targetOffset = $target.offset().top - navbarHeight;
+			if (target)
+				targetOffset = window.pageYOffset + target.getBoundingClientRect().y - navbarHeight;
 			// Scroll in 0.75 seconds
 			$('html, body').animate({
 				scrollTop: targetOffset
@@ -99,5 +110,5 @@ $(function () {
 			// Omit browser link processing
 			return false;
 		});
-	});
-});
+	}
+}();

--- a/js/jquery.cslider.js
+++ b/js/jquery.cslider.js
@@ -1,6 +1,6 @@
 // Original: https://github.com/Le-Stagiaire/jquery.cslider/blob/0c99322/src/jquery.cslider.js
 'use strict';
-(function ($) {
+!function () {
     $.Slider = function (options, element) {
         this.$el = $(element);
         this._init(options);
@@ -156,4 +156,4 @@
         }
         return this;
     };
-})(jQuery);
+}();

--- a/stats.html
+++ b/stats.html
@@ -33,12 +33,12 @@
 		<meta name="theme-color" content="#000000">
 		<!-- Load CSS styles -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
-		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=6">
+		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
 		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
-		<script defer src="js/app.min.js"></script>
+		<script defer src="js/app.min.js?v=1"></script>
 	</head>
 	<body>
 		<nav class="navbar navbar-expand-lg">
@@ -75,7 +75,7 @@
 					<button class="nav-link filter" data-filter=".armbian">Armbian</button>
 					<button class="nav-link filter" data-filter=".debian">Debian</button>
 				</nav>
-				<div id="commands" class="toggleDiv single-project">
+				<div id="commands" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>Commands to derive data</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -96,7 +96,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="raspberrypios1" class="toggleDiv single-project">
+				<div id="raspberrypios1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (32-bit)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -120,7 +120,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="raspberrypios2" class="toggleDiv single-project">
+				<div id="raspberrypios2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (64-bit)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -144,7 +144,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="armbian1" class="toggleDiv single-project">
+				<div id="armbian1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -168,7 +168,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="armbian2" class="toggleDiv single-project">
+				<div id="armbian2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -192,7 +192,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="armbian3" class="toggleDiv single-project">
+				<div id="armbian3" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -216,7 +216,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="debian1" class="toggleDiv single-project">
+				<div id="debian1" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -240,7 +240,7 @@
 						</div>
 					</div>
 				</div>
-				<div id="debian2" class="toggleDiv single-project">
+				<div id="debian2" class="single-project">
 					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="show_hide close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
@@ -352,7 +352,7 @@
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.toggleDiv').forEach(function(e){e.setAttribute("style","display:none");});
+			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
 			document.getElementById("distrostats").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>


### PR DESCRIPTION
Successor of #228 part 1. Quite similar regarding `app.js` but avoiding some bugs (non-hiding SBC description when filtering, non-highlighting navigation buttons when scrolling) and with some performance enhancements:
- Native for loops instead of `forEach`
- Storing all used elements in global variables once, to avoid CSS selector queries on event
- Enhance strange previous `cur` (navbar element to highlight based on scroll position) estimation
- Break loop through elements once the last which is to be handled has been reached

Missing are:
- Scrollup/down if selected SBC details, which is done quite nicely in #228. I'll do it similar, but with an `active` class toggle.
- Smooth scrolling. `scroll-behavior: smooth;` did not work OOTB in my case in the past with Opera (Chromium-based), will test again.
- Slider: Will convert it to native JavaScript just the same way, but compared to #228 want to keep it and not use another package.