### PR TITLE
Remove further jQuery usage

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -35,7 +35,6 @@
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
-		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js?v=1"></script>
@@ -95,7 +94,7 @@
 				</nav>
 				<!-- Bug report -->
 				<div id="bugreport" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Create a new bug report / Report a security issue</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Create a new bug report / Report a security issue</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>
@@ -109,7 +108,7 @@
 				</div>
 				<!-- Diagnose -->
 				<div id="diagnose" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Investigate issues / Provide help</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Investigate issues / Provide help</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>Many times the DietPi project needs help on existent items:</p>
@@ -130,7 +129,7 @@
 				</div>
 				<!-- Question -->
 				<div id="question" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Answer questions / Provide insights</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Answer questions / Provide insights</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>Start a discussion, ask and answer questions. There are many questions on <a href="https://github.com/MichaIng/DietPi/issues" target="_blank" rel="noopener">the DietPi GitHub repository</a> and on our <a href="https://dietpi.com/forum/" target="_blank" rel="noopener">forum</a> for which you may have already the answers, or you could provide valuable insights.</p>
@@ -141,7 +140,7 @@
 				</div>
 				<!-- Test -->
 				<div id="test" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Test configurations</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Test configurations</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>DietPi supports multiple SBCs or PC / VM configurations. Very similar with investigating the issues, but specific to hardware, we need your help to run tests and specific installations for certain SBC models or PCs</p>
@@ -158,7 +157,7 @@
 				</div>
 				<!-- Improve website -->
 				<div id="improvewebsite" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Improve DietPi website</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Improve DietPi website</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>Web development is a dynamic and challenging field. Someone with skills in graphics and web design could provide a help to the overall online presence of this open-source project.</p>
@@ -170,7 +169,7 @@
 				</div>
 				<!-- Improve docs -->
 				<div id="improvedocs" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Expand DietPi Docs</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Expand DietPi Docs</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>This is an ever growing topic. Please join us to update documentation, bringing more examples and details, making the project easy to use and access.</p>
@@ -181,7 +180,7 @@
 				</div>
 				<!-- Suggest -->
 				<div id="suggest" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>New feature suggestions & Software titles</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>New feature suggestions & Software titles</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>Do you like the project and you would like to see new software titles or new configuration features?</p>
@@ -195,7 +194,7 @@
 				</div>
 				<!-- Code -->
 				<div id="code" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Extend DietPi</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Extend DietPi</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>
@@ -214,7 +213,7 @@
 				</div>
 				<!-- Community -->
 				<div id="community" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Use DietPi Forum</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Use DietPi Forum</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>Discuss with community.</p>
@@ -229,7 +228,7 @@
 				</div>
 				<!-- Blog -->
 				<div id="blog" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Write about DietPi</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Write about DietPi</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>
@@ -243,7 +242,7 @@
 				</div>
 				<!-- Social -->
 				<div id="social" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Social media</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Social media</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<p>This could be as simple as a Twitter Like, or re-share a conversation, article, feature via a Retweet. Or maybe adding a link to a Facebook post, or a Reddit reference.</p>
@@ -256,35 +255,35 @@
 				<div id="portfolio-grid" class="row" style="display:none">
 					<!-- Desktops -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Report">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#bugreport">
+						<a href="#contributeinfo" class="thumbnail" rel="#bugreport">
 							<img src="images/contribute/diagnose.jpg" alt="Report an issue" width="8" height="5" loading="lazy">
 							<h3>Report an issue</h3>
 							<p>Bugs or security issues</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Report">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#diagnose">
+						<a href="#contributeinfo" class="thumbnail" rel="#diagnose">
 							<img src="images/contribute/investigate.jpg" alt="Investigate / Help" width="8" height="5" loading="lazy">
 							<h3>Diagnose issues</h3>
 							<p>Investigate & Find reasons</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Report">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#question">
+						<a href="#contributeinfo" class="thumbnail" rel="#question">
 							<img src="images/contribute/question.jpg" alt="Question" width="8" height="5" loading="lazy">
 							<h3>Answer questions</h3>
 							<p>Share feedback and insights</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Report">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#test">
+						<a href="#contributeinfo" class="thumbnail" rel="#test">
 							<img src="images/contribute/test-configurations.jpg" alt="Test" width="8" height="5" loading="lazy">
 							<h3>Test configurations</h3>
 							<p>Run specific tests</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Ideas">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#improvewebsite">
+						<a href="#contributeinfo" class="thumbnail" rel="#improvewebsite">
 							<img src="images/contribute/improve-website.jpg" alt="Improve website" width="8" height="5" loading="lazy">
 							<h3>Improve DietPi website</h3>
 							<p>Help to improve & extend</p>
@@ -292,42 +291,42 @@
 					</div>
 					<!-- Remote desktop -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Ideas">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#improvedocs">
+						<a href="#contributeinfo" class="thumbnail" rel="#improvedocs">
 							<img src="images/contribute/improve-docs.jpg" alt="Improve docs" width="8" height="5" loading="lazy">
 							<h3>Extend DietPi Docs</h3>
 							<p>Bring more details & samples</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Ideas">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#suggest">
+						<a href="#contributeinfo" class="thumbnail" rel="#suggest">
 							<img src="images/contribute/new-features.jpg" alt="Suggest" width="8" height="5" loading="lazy">
 							<h3>New software titles</h3>
 							<p>Suggest features & software</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Expand">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#code">
+						<a href="#contributeinfo" class="thumbnail" rel="#code">
 							<img src="images/contribute/expand-code.jpg" alt="Code" width="8" height="5" loading="lazy">
 							<h3>Extend DietPi</h3>
 							<p>Bring contributions in GitHub</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Community">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#community">
+						<a href="#contributeinfo" class="thumbnail" rel="#community">
 							<img src="images/contribute/be-part-community.jpg" alt="Community" width="8" height="5" loading="lazy">
 							<h3>Use DietPi Forum</h3>
 							<p>Share & Receive help</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Community">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#blog">
+						<a href="#contributeinfo" class="thumbnail" rel="#blog">
 							<img src="images/contribute/social-Twitter.jpg" alt="Blog" width="8" height="5" loading="lazy">
 							<h3>Write about DietPi</h3>
 							<p>Spread the word</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Community">
-						<a href="#contributeinfo" class="thumbnail show_hide" rel="#social">
+						<a href="#contributeinfo" class="thumbnail" rel="#social">
 							<img src="images/contribute/more-social.jpg" alt="Social" width="8" height="5" loading="lazy">
 							<h3>Social media</h3>
 							<p>Share info & love</p>
@@ -366,7 +365,7 @@
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
+			for (let x of document.querySelectorAll('div.single-project')) x.classList.add('hidden');
 			document.getElementById("contributeinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,10 @@
 /*
 1. General
 **********************************************************************/
+html {
+	scroll-behavior: smooth;
+	scroll-padding-top: 60px;
+}
 body {
 	font-family: Arial, sans-serif;
 	color: #ffffff;
@@ -56,7 +60,7 @@ a:active {
 	z-index: 1;
 	min-height: 60px;
 	background-color: #164046;
-	padding: 4.5px 15px;
+	padding: 5px 15px;
 }
 .navbar > .container-xl {
 	padding: 0;
@@ -64,12 +68,12 @@ a:active {
 .navbar > .container-xl > img {
 	width: 120px;
 	height: 40px;
-	margin: 5.5px 0;
+	margin: 5px 0;
 }
 .navbar > .container-xl > .navbar-toggler {
 	width: 40px;
 	height: 40px;
-	margin: 5.5px 0;
+	margin: 5px 0;
 	padding: 10px;
 	background-color: #c5ff00;
 	border-color: #164046;
@@ -99,7 +103,7 @@ a:active {
 .navbar > .container-xl > .navbar-collapse > a {
 	color: #ffffff;
 	font-size: 15px;
-	margin: 4.5px 0;
+	margin: 4px 0;
 	padding: 10px 14px;
 	border: 1px solid #164046;
 	border-radius: 4px;
@@ -354,9 +358,15 @@ a:active {
 3.2 Details frame
 **********************************************************************/
 .single-project {
-	margin-bottom: 30px;
 	background-color: #181a1c;
 	border-radius: 4px;
+	margin-bottom: 30px;
+	overflow-y: clip;
+	transition: height 0.5s, margin-bottom 0.5s;
+}
+.single-project.hidden {
+	height: 0;
+	margin-bottom: 0;
 }
 .project-title {
 	border-bottom: 1px solid #9ccc00;

--- a/dietpi-software.html
+++ b/dietpi-software.html
@@ -35,7 +35,6 @@
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
-		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js?v=1"></script>
@@ -100,7 +99,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>LXDE</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#lxde" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -126,7 +125,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>MATE</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#mate" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -151,7 +150,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Xfce</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#xfce" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -176,7 +175,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>GNUstep</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#gnustep" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -201,7 +200,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Chromium</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#chromium" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -232,7 +231,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>TigerVNC Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#tigervnc-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -251,7 +250,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>NoMachine</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#nomachine" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -271,7 +270,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>XRDP</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#xrdp" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -290,7 +289,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>RealVNC</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#realvnc-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -310,7 +309,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Kodi</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#kodi" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -329,7 +328,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>ympd</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#ympd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -349,7 +348,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>O!MPD</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#ompd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -369,7 +368,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>CAVA</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#cava" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -388,7 +387,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Mopidy</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#mopidy" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -407,7 +406,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Airsonic</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#airsonic" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -427,7 +426,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Logitech Media Server & Squeezelite</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#logitech-media-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -448,7 +447,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>ReadyMedia (MiniDLNA)</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#readymedia" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -468,7 +467,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Shairport Sync</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#shairport-sync" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -488,7 +487,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Ampache</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#ampache" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -508,7 +507,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Emby</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#emby" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -528,7 +527,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Plex Media Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#plex-media-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -548,7 +547,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Tautulli</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#tautulli" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -568,7 +567,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Murmur - Mumble VoIP Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#murmur" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -588,7 +587,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Roon Bridge</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#roon-bridge" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -608,7 +607,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Roon Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#roon-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -628,7 +627,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>NAA Daemon</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#naa-daemon" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -648,7 +647,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>IceCast & DarkIce</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#icecast" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -668,7 +667,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Koel</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#koel" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -688,7 +687,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>GMediaRender</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#gmediarender" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -708,7 +707,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Transmission</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#transmission" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -728,7 +727,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Deluge</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#deluge" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -748,7 +747,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>qBittorrent</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#qbittorrent" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -768,7 +767,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>rTorrent</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#rtorrent" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -788,7 +787,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Aria2</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#aria2" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -809,7 +808,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>SABnzbd</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#sabnzbd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -830,7 +829,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Medusa</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#medusa" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -850,7 +849,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Sonarr</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#sonarr" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -870,7 +869,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Radarr</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#radarr" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -890,7 +889,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Jackett</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#jackett" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -910,7 +909,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>NZBGet</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#nzbget" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -930,7 +929,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>HTPC Manager</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#htpc-manager" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -950,7 +949,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>OpenTyrian</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#opentyrian" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -969,7 +968,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Cuberite</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#cuberite" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -988,7 +987,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>MineOS</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#mineos" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1007,7 +1006,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Nukkit</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#nukkit" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1026,7 +1025,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Amiberry</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1045,7 +1044,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>DXX-Rebirth</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#dxx-rebirth" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1064,7 +1063,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Steam</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/gaming/#steam" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1083,7 +1082,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>RPi Cam Control</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/camera/#rpi-cam-control" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1102,7 +1101,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>MotionEye</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/camera/#motioneye" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1121,7 +1120,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>ownCloud</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#owncloud" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1140,7 +1139,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Nextcloud</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#nextcloud" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1159,7 +1158,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Pydio</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#pydio" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1178,7 +1177,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>UrBackup Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#urbackup" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1197,7 +1196,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Gogs</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#gogs" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1216,7 +1215,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Gitea</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#gitea" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1235,7 +1234,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Syncthing</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#syncthing" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1254,7 +1253,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>MinIO</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/cloud/#minio" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1273,7 +1272,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>phpBB</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#phpbb" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1292,7 +1291,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Wordpress</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#wordpress" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1311,7 +1310,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Single File PHP Gallery</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#single-file-php-gallery" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1330,7 +1329,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Baïkal</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#baikal" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1349,7 +1348,7 @@
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>OpenBazaar</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#openbazaar" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1369,7 +1368,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>YaCy</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#yacy" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1388,7 +1387,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>WiFi HotSpot</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/advanced_networking/#wifi-hotspot" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1407,7 +1406,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Tor HotSpot</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/advanced_networking/#tor-hotspot" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1426,7 +1425,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Home Assistant</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/home_automation/#home-assistant" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1445,7 +1444,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Google AIY Kit</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#google-aiy" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1464,7 +1463,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>PiJuice</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#pijuice" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1483,7 +1482,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>RPi.GPIO</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#rpigpio" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1502,7 +1501,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>WiringPi</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#wiringpi" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1521,7 +1520,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>WebIOPi</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#webiopi" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1540,7 +1539,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Node-RED</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#node-red" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1559,7 +1558,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Mosquitto</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#mosquitto" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1578,7 +1577,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Blynk Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#blynk-server" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1597,7 +1596,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Audiophonics Pi-SPC</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#audiophonics-pi-spc" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1616,7 +1615,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>InfluxDB</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#influxdb" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1636,7 +1635,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Grafana</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/hardware_projects/#grafana" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1656,7 +1655,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Remot3.it (Weaved)</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#remot3it" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1675,7 +1674,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>VirtualHere</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/remote_desktop/#virtualhere" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1694,7 +1693,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>DietPi-CloudShell</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#dietpi-cloudshell" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1713,7 +1712,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Linux Dash</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#linux-dash" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1732,7 +1731,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>phpSysInfo</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#phpsysinfo" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1751,7 +1750,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>RPi Monitor</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#rpi-monitor" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1770,7 +1769,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Netdata</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#netdata" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1789,7 +1788,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Webmin</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_stats/#webmin" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1808,7 +1807,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Fail2Ban</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_security/#fail2ban" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1827,7 +1826,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Apache2</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/webserver_stack/#apache2" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1847,7 +1846,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Nginx</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/webserver_stack/#nginx" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1867,7 +1866,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Lighttpd</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/webserver_stack/#lighttpd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1887,7 +1886,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>phpMyAdmin</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/webserver_stack/#phpmyadmin" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1903,7 +1902,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Certbot</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/system_security/#lets-encrypt" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1922,7 +1921,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Tomcat</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/webserver_stack/#tomcat" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1938,7 +1937,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Pi-hole</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/dns_servers/#pi-hole" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1957,7 +1956,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>ProFTPD</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/file_servers/#proftpd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1976,7 +1975,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Samba Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/file_servers/#samba" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -1995,7 +1994,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>vsftpd</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/file_servers/#vsftpd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2014,7 +2013,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>NFS</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/file_servers/#nfs" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2033,7 +2032,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>OpenVPN</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/vpn/#openvpn" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2052,7 +2051,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>PiVPN</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/vpn/#pivpn" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2071,7 +2070,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>OctoPrint</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/printing/#octoprint" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2090,7 +2089,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>HAProxy</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/advanced_networking/#haproxy" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2109,7 +2108,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Dropbear</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/ssh/#dropbear" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2128,7 +2127,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>OpenSSH Server</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/ssh/#openssh" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2147,7 +2146,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>DietPi-RAMlog</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/log_system/#dietpi-ramlog" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2166,7 +2165,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Full Logging</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/log_system/#full-logging" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2185,7 +2184,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Roon Extension Manager</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#roon-extension-manager" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2204,7 +2203,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Ubooquity</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#ubooquity" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2223,7 +2222,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Lidarr</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/bittorrent/#lidarr" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2242,7 +2241,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>Folding@Home</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/distributed_projects/#foldinghome" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2261,7 +2260,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>FreshRSS</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/social/#freshrss" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2280,7 +2279,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>myMPD</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/media/#mympd" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2299,7 +2298,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 						<div class="project-description">
 							<div class="project-title clearfix">
 								<h3>LXQt</h3>
-								<span class="show_hide close"></span>
+								<span class="close"></span>
 							</div>
 							<div class="project-info">
 								<div><a href="https://dietpi.com/docs/software/desktop/#lxqt" target="_blank" rel="noopener"><span>How to Setup / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -2321,42 +2320,42 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 				<div id="portfolio-grid" class="row" style="display:none">
 					<!-- Desktops -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv1">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv1">
 							<img src="images/dietpi-software/lxde_0.jpg" alt="LXDE" width="8" height="5" loading="lazy">
 							<h3>LXDE</h3>
 							<p>Ultra Lightweight Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv119">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv119">
 							<img src="images/dietpi-software/lxqt_0.jpg" alt="LXQt" width="8" height="5" loading="lazy">
 							<h3>LXQt</h3>
 							<p>Lightweight Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv2">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv2">
 							<img src="images/dietpi-software/mate_0.jpg" alt="project 2" width="8" height="5" loading="lazy">
 							<h3>MATE</h3>
 							<p>Lightweight Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv3">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv3">
 							<img src="images/dietpi-software/xfce_0.jpg" alt="project 3" width="8" height="5" loading="lazy">
 							<h3>Xfce</h3>
 							<p>Lightweight Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv4">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv4">
 							<img src="images/dietpi-software/gnustep_0.jpg" alt="project 4" width="8" height="5" loading="lazy">
 							<h3>GNUstep</h3>
 							<p>Alternative/unique Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Desktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv5">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv5">
 							<img src="images/dietpi-software/chromium_0.jpg" alt="project 5" width="8" height="5" loading="lazy">
 							<h3>Chromium</h3>
 							<p>Web browser + Kiosk mode</p>
@@ -2364,28 +2363,28 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 					<!-- Remote desktop -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RDesktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv6">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv6">
 							<img src="images/dietpi-software/vnc_0.jpg" alt="project 6" width="8" height="5" loading="lazy">
 							<h3>TigerVNC</h3>
 							<p>Remote Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RDesktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv7">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv7">
 							<img src="images/dietpi-software/nomachine_0.jpg" alt="project 7" width="8" height="5" loading="lazy">
 							<h3>NoMachine</h3>
 							<p>Remote Desktop Solution</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RDesktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv8">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv8">
 							<img src="images/dietpi-software/xrdp_0.jpg" alt="project 8" width="8" height="5" loading="lazy">
 							<h3>XRDP</h3>
 							<p>Remote Desktop</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RDesktops">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv9">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv9">
 							<img src="images/dietpi-software/realvnc_0.jpg" alt="project 9" width="8" height="5" loading="lazy">
 							<h3>RealVNC</h3>
 							<p>Remote Desktop</p>
@@ -2393,161 +2392,161 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 					<!-- Media -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv10">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv10">
 							<img src="images/dietpi-software/kodi_0.jpg" alt="project 10" width="8" height="5" loading="lazy">
 							<h3>Kodi</h3>
 							<p>Media Centre</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv11">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv11">
 							<img src="images/dietpi-software/ympd_0.jpg" alt="project 11" width="8" height="5" loading="lazy">
 							<h3>ympd</h3>
 							<p>Lightweight MPD web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv117">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv117">
 							<img src="images/dietpi-software/mympd_0.jpg" alt="project 117" width="8" height="5" loading="lazy">
 							<h3>myMPD</h3>
 							<p>Lightweight MPD web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv12">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv12">
 							<img src="images/dietpi-software/ompd_0.jpg" alt="project 12" width="8" height="5" loading="lazy">
 							<h3>O!MPD</h3>
 							<p>Feature-rich MPD web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv13">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv13">
 							<img src="images/dietpi-software/cava_0.jpg" alt="project 13" width="8" height="5" loading="lazy">
 							<h3>CAVA</h3>
 							<p>Console Audio Visualizer for MPD</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv14">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv14">
 							<img src="images/dietpi-software/mopidy_0.jpg" alt="project 14" width="8" height="5" loading="lazy">
 							<h3>Mopidy</h3>
 							<p>Web interface Audio Player</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv15">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv15">
 							<img src="images/dietpi-software/airsonic_0.jpg" alt="project 15" width="8" height="5" loading="lazy">
 							<h3>Airsonic</h3>
 							<p>Web interface Audio Player</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv17">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv17">
 							<img src="images/dietpi-software/squeezebox_0.jpg" alt="project 17" width="8" height="5" loading="lazy">
 							<h3>Logitech Media Server</h3>
 							<p>Web interface Audio Server/Player</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv18">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv18">
 							<img src="images/dietpi-software/readymedia_0.jpg" alt="project 18" width="8" height="5" loading="lazy">
 							<h3>ReadyMedia (MiniDLNA)</h3>
 							<p>Media Streaming Server (DLNA, UPnP)</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv19">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv19">
 							<img src="images/dietpi-software/shairportsync_0.jpg" alt="project 19" width="8" height="5" loading="lazy">
 							<h3>Shairport Sync</h3>
 							<p>AirPlay Audio Player & Multiroom Sync</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv20">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv20">
 							<img src="images/dietpi-software/ampache_0.jpg" alt="project 20" width="8" height="5" loading="lazy">
 							<h3>Ampache</h3>
 							<p>Web interface Media Streamer</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv21">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv21">
 							<img src="images/dietpi-software/emby_0.jpg" alt="project 21" width="8" height="5" loading="lazy">
 							<h3>Emby</h3>
 							<p>Web interface Media Streamer</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv22">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv22">
 							<img src="images/dietpi-software/plex_0.jpg" alt="project 22" width="8" height="5" loading="lazy">
 							<h3>Plex</h3>
 							<p>Web interface Media Streamer</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv23">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv23">
 							<img src="images/dietpi-software/plexpy_0.jpg" alt="project 23" width="8" height="5" loading="lazy">
 							<h3>Tautulli</h3>
 							<p>Monitoring and analytics for Plex</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv24">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv24">
 							<img src="images/dietpi-software/mumble_0.jpg" alt="project 24" width="8" height="5" loading="lazy">
 							<h3>Murmur/Mumble VoIP</h3>
 							<p>lightweight Mumble VoIP server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv25">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv25">
 							<img src="images/dietpi-software/roon_0.jpg" alt="project 25" width="8" height="5" loading="lazy">
 							<h3>Roon Bridge</h3>
 							<p>Endpoint/audio playback</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv26">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv26">
 							<img src="images/dietpi-software/roon_0.jpg" alt="project 26" width="8" height="5" loading="lazy">
 							<h3>Roon Server</h3>
 							<p>Endpoint audio playback & core server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv112">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv112">
 							<img src="images/dietpi-software/roon_0.jpg" alt="project 112" width="8" height="5" loading="lazy">
 							<h3>Roon Extension Manager</h3>
 							<p>Manage Roon extensions</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv27">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv27">
 							<img src="images/dietpi-software/naa_0.jpg" alt="project 27" width="8" height="5" loading="lazy">
 							<h3>NAA Daemon</h3>
 							<p>Signalyst network audio adaptor</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv28">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv28">
 							<img src="images/dietpi-software/icecast_0.jpg" alt="project 28" width="8" height="5" loading="lazy">
 							<h3>IceCast & DarkIce</h3>
 							<p>Shoutcast streaming server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv29">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv29">
 							<img src="images/dietpi-software/koel_0.jpg" alt="project 29" width="8" height="5" loading="lazy">
 							<h3>Koel</h3>
 							<p>Web interface streaming server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv30">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv30">
 							<img src="images/dietpi-software/gmrender_0.jpg" alt="project 30" width="8" height="5" loading="lazy">
 							<h3>GMediaRender</h3>
 							<p>DLNA audio render/endpoint</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Media">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv113">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv113">
 							<img src="images/dietpi-software/ubooquity_0.jpg" alt="project 113" width="8" height="5" loading="lazy">
 							<h3>Ubooquity</h3>
 							<p>Web server for comics/books</p>
@@ -2555,560 +2554,560 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					</div>
 					<!-- Downloads -->
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv31">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv31">
 							<img src="images/dietpi-software/transmission_0.jpg" alt="project 31" width="8" height="5" loading="lazy">
 							<h3>Transmission</h3>
 							<p>Lightweight BitTorrent server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv32">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv32">
 							<img src="images/dietpi-software/deluge_0.jpg" alt="project 32" width="8" height="5" loading="lazy">
 							<h3>Deluge</h3>
 							<p>BitTorrent server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv33">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv33">
 							<img src="images/dietpi-software/qbittorrent_0.jpg" alt="project 33" width="8" height="5" loading="lazy">
 							<h3>qBittorrent</h3>
 							<p>BitTorrent server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv34">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv34">
 							<img src="images/dietpi-software/rtorrent_0.jpg" alt="project 34" width="8" height="5" loading="lazy">
 							<h3>rTorrent</h3>
 							<p>BitTorrent server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv35">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv35">
 							<img src="images/dietpi-software/aria2_0.jpg" alt="project 35" width="8" height="5" loading="lazy">
 							<h3>Aria2</h3>
 							<p>Web interface download manager</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv36">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv36">
 							<img src="images/dietpi-software/sabnzbd_0.jpg" alt="project 36" width="8" height="5" loading="lazy">
 							<h3>SABnzbd</h3>
 							<p>Web interface NZB download manager</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv37">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv37">
 							<img src="images/dietpi-software/medusa_0.jpg" alt="project 37" width="8" height="5" loading="lazy">
 							<h3>Medusa</h3>
 							<p>Automatically download TV shows</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv38">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv38">
 							<img src="images/dietpi-software/sonarr_0.jpg" alt="project 38" width="8" height="5" loading="lazy">
 							<h3>Sonarr</h3>
 							<p>Automatically download TV shows</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv39">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv39">
 							<img src="images/dietpi-software/radarr_0.jpg" alt="project 39" width="8" height="5" loading="lazy">
 							<h3>Radarr</h3>
 							<p>Automatically download movies</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv114">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv114">
 							<img src="images/dietpi-software/lidarr_0.jpg" alt="project 114" width="8" height="5" loading="lazy">
 							<h3>Lidarr</h3>
 							<p>Automatically download music</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv41">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv41">
 							<img src="images/dietpi-software/jackett_0.jpg" alt="project 41" width="8" height="5" loading="lazy">
 							<h3>Jackett</h3>
 							<p>API support for torrent trackers</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv42">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv42">
 							<img src="images/dietpi-software/nzbget_0.jpg" alt="project 42" width="8" height="5" loading="lazy">
 							<h3>NZBGet</h3>
 							<p>Web interface NZB download manager</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Download">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv43">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv43">
 							<img src="images/dietpi-software/htpcmanager_0.jpg" alt="project 43" width="8" height="5" loading="lazy">
 							<h3>HTPC Manager</h3>
 							<p>Combines all your favorite DL software</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv44">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv44">
 							<img src="images/dietpi-software/opentyrian_0.jpg" alt="project 44" width="8" height="5" loading="lazy">
 							<h3>OpenTyrian</h3>
 							<p>Classic gaming</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv45">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv45">
 							<img src="images/dietpi-software/cuberite_0.jpg" alt="project 45" width="8" height="5" loading="lazy">
 							<h3>Cuberite</h3>
 							<p>Minecraft server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv46">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv46">
 							<img src="images/dietpi-software/mineos_0.jpg" alt="project 46" width="8" height="5" loading="lazy">
 							<h3>MineOS</h3>
 							<p>Minecraft servers & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv47">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv47">
 							<img src="images/dietpi-software/nukkit_0.jpg" alt="project 47" width="8" height="5" loading="lazy">
 							<h3>Nukkit</h3>
 							<p>Server for Minecraft Pocket Edition</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv48">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv48">
 							<img src="images/dietpi-software/amiberry_0.jpg" alt="project 48" width="8" height="5" loading="lazy">
 							<h3>Amiberry</h3>
 							<p>Optimized Amiga emulation system</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv49">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv49">
 							<img src="images/dietpi-software/dxxrebirth_0.jpg" alt="project 49" width="8" height="5" loading="lazy">
 							<h3>DXX-Rebirth</h3>
 							<p>Descent 1 & 2 OpenGL port</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Gaming">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv50">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv50">
 							<img src="images/dietpi-software/steam_0.jpg" alt="project 50" width="8" height="5" loading="lazy">
 							<h3>Steam</h3>
 							<p>Steam client</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Camera">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv51">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv51">
 							<img src="images/dietpi-software/rpicamcontrol_0.jpg" alt="project 51" width="8" height="5" loading="lazy">
 							<h3>RPi Cam Control</h3>
 							<p>Camera & Web Interface Surveillance</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Camera">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv52">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv52">
 							<img src="images/dietpi-software/motioneye_0.jpg" alt="project 52" width="8" height="5" loading="lazy">
 							<h3>MotionEye</h3>
 							<p>Camera & Web Interface Surveillance</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv53">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv53">
 							<img src="images/dietpi-software/owncloud_0.jpg" alt="project 53" width="8" height="5" loading="lazy">
 							<h3>ownCloud</h3>
 							<p>Personal cloud backup/data system</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv54">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv54">
 							<img src="images/dietpi-software/nextcloud_0.jpg" alt="project 54" width="8" height="5" loading="lazy">
 							<h3>Nextcloud</h3>
 							<p>Personal cloud backup/data system</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv55">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv55">
 							<img src="images/dietpi-software/pydio_0.jpg" alt="project 55" width="8" height="5" loading="lazy">
 							<h3>Pydio</h3>
 							<p>Backup/sync server & web interface.</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv56">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv56">
 							<img src="images/dietpi-software/urbackup_0.jpg" alt="project 56" width="8" height="5" loading="lazy">
 							<h3>UrBackup Server</h3>
 							<p>Remote system backups</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv57">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv57">
 							<img src="images/dietpi-software/gogs_0.jpg" alt="project 57" width="8" height="5" loading="lazy">
 							<h3>Gogs</h3>
 							<p>GitHub style server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv58">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv58">
 							<img src="images/dietpi-software/gitea_0.jpg" alt="project 58" width="8" height="5" loading="lazy">
 							<h3>Gitea</h3>
 							<p>GitHub style server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv59">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv59">
 							<img src="images/dietpi-software/syncthing_0.jpg" alt="project 59" width="8" height="5" loading="lazy">
 							<h3>Syncthing</h3>
 							<p>Backup/sync server & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Cloud">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv61">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv61">
 							<img src="images/dietpi-software/minio_0.jpg" alt="project 61" width="8" height="5" loading="lazy">
 							<h3>MinIO</h3>
 							<p>S3 compatible distributed object server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv116">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv116">
 							<img src="images/dietpi-software/freshrss_0.jpg" alt="project 116" width="8" height="5" loading="lazy">
 							<h3>FreshRSS</h3>
 							<p>Self-hosted RSS feed aggregator</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv62">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv62">
 							<img src="images/dietpi-software/phpbb3_0.jpg" alt="project 62" width="8" height="5" loading="lazy">
 							<h3>phpBB</h3>
 							<p>Forums (Same as ours!)</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv63">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv63">
 							<img src="images/dietpi-software/wordpress_0.jpg" alt="project 63" width="8" height="5" loading="lazy">
 							<h3>Wordpress</h3>
 							<p>Blog and Publishing platform</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv64">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv64">
 							<img src="images/dietpi-software/imageallery_0.jpg" alt="project 64" width="8" height="5" loading="lazy">
 							<h3>Single File PHP Gallery</h3>
 							<p>Host/browse images via web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv65">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv65">
 							<img src="images/dietpi-software/baikal_0.jpg" alt="project 65" width="8" height="5" loading="lazy">
 							<h3>Baïkal</h3>
 							<p>CalDAV + CardDAV server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv66">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv66">
 							<img src="images/dietpi-software/openbazaar_0.jpg" alt="project 66" width="8" height="5" loading="lazy">
 							<h3>OpenBazaar</h3>
 							<p>Market server for Bitcoin</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv67">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv67">
 							<img src="images/dietpi-software/yacy_0.jpg" alt="project 67" width="8" height="5" loading="lazy">
 							<h3>YaCy</h3>
 							<p>Decentralized search engine</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WiFi">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv68">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv68">
 							<img src="images/dietpi-software/wifihotspot_0.jpg" alt="project 68" width="8" height="5" loading="lazy">
 							<h3>WiFi HotSpot</h3>
 							<p>Regular WPA WiFi HotSpot</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WiFi">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv69">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv69">
 							<img src="images/dietpi-software/torwifihotspot_0.jpg" alt="Tor WiFi logo" width="8" height="5" loading="lazy">
 							<h3>Tor HotSpot</h3>
 							<p>Tor enabled WiFi HotSpot</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Automation">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv70">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv70">
 							<img src="images/dietpi-software/homeassistant_0.jpg" alt="project 70" width="8" height="5" loading="lazy">
 							<h3>Home Assistant</h3>
 							<p>Home automation platform</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv71">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv71">
 							<img src="images/dietpi-software/googleaiy_0.jpg" alt="project 71" width="8" height="5" loading="lazy">
 							<h3>Google AIY</h3>
 							<p>Voice kit "Ok, Google"!</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv72">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv72">
 							<img src="images/dietpi-software/pijuice_0.jpg" alt="project 72" width="8" height="5" loading="lazy">
 							<h3>PiJuice</h3>
 							<p>PiSupply UPS/battery system</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv73">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv73">
 							<img src="images/dietpi-software/rpigpio_0.jpg" alt="project 73" width="8" height="5" loading="lazy">
 							<h3>RPi.GPIO</h3>
 							<p>GPIO Interface library for RPi</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv74">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv74">
 							<img src="images/dietpi-software/rpigpio_0.jpg" alt="project 74" width="8" height="5" loading="lazy">
 							<h3>WiringPi</h3>
 							<p>GPIO Interface library</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv75">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv75">
 							<img src="images/dietpi-software/webiopi_0.jpg" alt="project 75" width="8" height="5" loading="lazy">
 							<h3>WebIOPi</h3>
 							<p>Web interface to control GPIO</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv76">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv76">
 							<img src="images/dietpi-software/nodered_0.jpg" alt="project 76" width="8" height="5" loading="lazy">
 							<h3>Node-RED</h3>
 							<p>Visual tool for wiring hardware devices</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv77">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv77">
 							<img src="images/dietpi-software/mosquitto_0.jpg" alt="project 77" width="8" height="5" loading="lazy">
 							<h3>Mosquitto</h3>
 							<p>Message broker (MQTT protocol)</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv78">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv78">
 							<img src="images/dietpi-software/blynkserver_0.jpg" alt="project 78" width="8" height="5" loading="lazy">
 							<h3>Blynk Server</h3>
 							<p>SBC remote control server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv79">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv79">
 							<img src="images/dietpi-software/pispc_0.jpg" alt="project 79" width="8" height="5" loading="lazy">
 							<h3>Audiophonics Pi-SPC</h3>
 							<p>Power control module for RPi</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv80">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv80">
 							<img src="images/dietpi-software/influxdb_0.jpg" alt="project 80" width="8" height="5" loading="lazy">
 							<h3>InfluxDB</h3>
 							<p>Database for sensor logging</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix HardwareProjects">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv81">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv81">
 							<img src="images/dietpi-software/grafana_0.jpg" alt="project 81" width="8" height="5" loading="lazy">
 							<h3>Grafana</h3>
 							<p>Beautiful analytics and monitoring</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RemoteAccess">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv82">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv82">
 							<img src="images/dietpi-software/remot3it_0.jpg" alt="project 82" width="8" height="5" loading="lazy">
 							<h3>Remot3.it</h3>
 							<p>Access device over the internet</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix RemoteAccess">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv83">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv83">
 							<img src="images/dietpi-software/virtualhere_0.jpg" alt="project 83" width="8" height="5" loading="lazy">
 							<h3>VirtualHere</h3>
 							<p>Share USB devices over your network</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv84">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv84">
 							<img src="images/dietpi-software/dietpi-cloudshell_0.jpg" alt="project 84" width="8" height="5" loading="lazy">
 							<h3>DietPi-CloudShell</h3>
 							<p>Lightweight system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv85">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv85">
 							<img src="images/dietpi-software/linuxdash_0.jpg" alt="project 85" width="8" height="5" loading="lazy">
 							<h3>Linux Dash</h3>
 							<p>Web interface system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv86">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv86">
 							<img src="images/dietpi-software/phpsysinfo_0.jpg" alt="project 86" width="8" height="5" loading="lazy">
 							<h3>phpSysInfo</h3>
 							<p>Web interface system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv87">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv87">
 							<img src="images/dietpi-software/rpimonitor_0.jpg" alt="project 87" width="8" height="5" loading="lazy">
 							<h3>RPi Monitor</h3>
 							<p>Web interface system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv88">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv88">
 							<img src="images/dietpi-software/netdata_0.jpg" alt="project 88" width="8" height="5" loading="lazy">
 							<h3>Netdata</h3>
 							<p>Web interface system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Stats">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv89">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv89">
 							<img src="images/dietpi-software/webmin_0.jpg" alt="project 89" width="8" height="5" loading="lazy">
 							<h3>Webmin</h3>
 							<p>Remote management & web interface</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Security">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv90">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv90">
 							<img src="images/dietpi-software/fail2ban_0.jpg" alt="project 90" width="8" height="5" loading="lazy">
 							<h3>Fail2Ban</h3>
 							<p>Brute-force attack protection</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv91">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv91">
 							<img src="images/dietpi-software/apache2_0.jpg" alt="project 91" width="8" height="5" loading="lazy">
 							<h3>Apache2</h3>
 							<p>LAMP / LASP</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv92">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv92">
 							<img src="images/dietpi-software/nginx_0.jpg" alt="project 92" width="8" height="5" loading="lazy">
 							<h3>Nginx</h3>
 							<p>LEMP / LESP</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv93">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv93">
 							<img src="images/dietpi-software/lighttpd_0.jpg" alt="project 93" width="8" height="5" loading="lazy">
 							<h3>Lighttpd</h3>
 							<p>LLMP / LLSP</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv94">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv94">
 							<img src="images/dietpi-software/phpmyadmin_0.jpg" alt="project 94" width="8" height="5" loading="lazy">
 							<h3>phpMyAdmin</h3>
 							<p>Web interface SQL admin tool</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv95">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv95">
 							<img src="images/dietpi-software/certbot_0.jpg" alt="project 95" width="8" height="5" loading="lazy">
 							<h3>Certbot</h3>
 							<p>Free SSL cert install/configuration</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix WebserverStacks">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv96">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv96">
 							<img src="images/dietpi-software/tomcat8_0.jpg" alt="project 96" width="8" height="5" loading="lazy">
 							<h3>Tomcat</h3>
 							<p>Apache Tomcat server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix DNS">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv97">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv97">
 							<img src="images/dietpi-software/pihole_0.jpg" alt="project 97" width="8" height="5" loading="lazy">
 							<h3>Pi-hole</h3>
 							<p>Network ad-blocker</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix FileServers">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv98">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv98">
 							<img src="images/dietpi-software/proftp_0.jpg" alt="project 98" width="8" height="5" loading="lazy">
 							<h3>ProFTPD</h3>
 							<p>Efficient, lightweight FTP file server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix FileServers">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv99">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv99">
 							<img src="images/dietpi-software/samba_0.jpg" alt="project 99" width="8" height="5" loading="lazy">
 							<h3>Samba Server</h3>
 							<p>Feature-rich file server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix FileServers">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv100">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv100">
 							<img src="images/dietpi-software/vsftpd_0.jpg" alt="project 100" width="8" height="5" loading="lazy">
 							<h3>vsftpd</h3>
 							<p>Feature-rich FTP file server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix FileServers">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv101">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv101">
 							<img src="images/dietpi-software/nfs_0.jpg" alt="project 101" width="8" height="5" loading="lazy">
 							<h3>NFS</h3>
 							<p>Network file server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix VPNServer">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv102">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv102">
 							<img src="images/dietpi-software/openvpn_0.jpg" alt="project 102" width="8" height="5" loading="lazy">
 							<h3>OpenVPN</h3>
 							<p>VPN server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix VPNServer">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv103">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv103">
 							<img src="images/dietpi-software/pivpn_0.jpg" alt="project 103" width="8" height="5" loading="lazy">
 							<h3>PiVPN</h3>
 							<p>OpenVPN management tool</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Printing">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv105">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv105">
 							<img src="images/dietpi-software/octoprint_0.jpg" alt="project 105" width="8" height="5" loading="lazy">
 							<h3>OctoPrint</h3>
 							<p>Web interface for 3D printers</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Misc">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv106">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv106">
 							<img src="images/dietpi-software/haproxy_0.jpg" alt="project 106" width="8" height="5" loading="lazy">
 							<h3>HAProxy</h3>
 							<p>TCP/HTTP load balancer</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix SSH">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv108">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv108">
 							<img src="images/dietpi-software/dropbear_0.jpg" alt="project 108" width="8" height="5" loading="lazy">
 							<h3>Dropbear</h3>
 							<p>Lightweight SSH server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix SSH">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv109">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv109">
 							<img src="images/dietpi-software/opensshserver_0.jpg" alt="project 109" width="8" height="5" loading="lazy">
 							<h3>OpenSSH Server</h3>
 							<p>Feature-rich SSH server</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix LOG">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv110">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv110">
 							<img src="images/dietpi-software/dietpiramlog_0.jpg" alt="project 110" width="8" height="5" loading="lazy">
 							<h3>DietPi-RAMlog</h3>
 							<p>Lightweight, performance logging</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix LOG">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv111">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv111">
 							<img src="images/dietpi-software/fulllogging_0.jpg" alt="project 111" width="8" height="5" loading="lazy">
 							<h3>Full Logging</h3>
 							<p>Rsyslog & Logrotate</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Misc">
-						<a href="#softwareinfo" class="thumbnail show_hide" rel="#slidingdiv115">
+						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv115">
 							<img src="images/dietpi-software/foldingathome_0.jpg" alt="project 115" width="8" height="5" loading="lazy">
 							<h3>Folding@Home</h3>
 							<p>Disease research</p>
@@ -3147,7 +3146,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
+			for (let x of document.querySelectorAll('div.single-project')) x.classList.add('hidden');
 			document.getElementById("softwareinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/index.html
+++ b/index.html
@@ -36,9 +36,9 @@
 		<link rel="stylesheet" type="text/css" href="css/jquery.cslider.min.css?v=3">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
-		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
-		<script defer src="js/jquery.cslider.min.js?v=1"></script>
+		<script defer src="js/jquery.min.js"></script>
+		<script defer src="js/jquery.cslider.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js?v=1"></script>
 	</head>
@@ -224,7 +224,7 @@
 					<button class="nav-link filter" data-filter=".other">Other</button>
 				</nav>
 				<div id="raspberrypi1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 1/Zero (1)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 1/Zero (1)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -248,7 +248,7 @@
 					</div>
 				</div>
 				<div id="raspberrypi2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2 PCB v1.1</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2 PCB v1.1</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -275,7 +275,7 @@
 					</div>
 				</div>
 				<div id="raspberrypi4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2/3/4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Raspberry Pi 2/3/4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -302,7 +302,7 @@
 					</div>
 				</div>
 				<div id="odroidc1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C1</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C1</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -322,7 +322,7 @@
 					</div>
 				</div>
 				<div id="odroidc2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -338,7 +338,7 @@
 					</div>
 				</div>
 				<div id="odroidxu3" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Odroid XU3/XU4/MC1/HC1/HC2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Odroid XU3/XU4/MC1/HC1/HC2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -354,7 +354,7 @@
 					</div>
 				</div>
 				<div id="pinea64" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>PINE A64</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>PINE A64</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -371,7 +371,7 @@
 					</div>
 				</div>
 				<div id="nanopineo" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -388,7 +388,7 @@
 					</div>
 				</div>
 				<div id="nanopineoair" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Air</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Air</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -406,7 +406,7 @@
 					</div>
 				</div>
 				<div id="nanopim1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -423,7 +423,7 @@
 					</div>
 				</div>
 				<div id="nanopim2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M2/T2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M2/T2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -440,7 +440,7 @@
 					</div>
 				</div>
 				<div id="nanopim3" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M3/T3</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M3/T3</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -457,7 +457,7 @@
 					</div>
 				</div>
 				<div id="pinebook" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -476,7 +476,7 @@
 					</div>
 				</div>
 				<div id="hyperv" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Hyper-V</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Hyper-V</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -491,7 +491,7 @@
 					</div>
 				</div>
 				<div id="parallels" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Parallels</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Parallels</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -506,7 +506,7 @@
 					</div>
 				</div>
 				<div id="utm" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>UTM</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>UTM</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -521,7 +521,7 @@
 					</div>
 				</div>
 				<div id="proxmox" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Proxmox</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Proxmox</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -536,7 +536,7 @@
 					</div>
 				</div>
 				<div id="odroidn2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Odroid N2(+)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Odroid N2(+)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -554,7 +554,7 @@
 					</div>
 				</div>
 				<div id="vmware" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>VMware/ESXi</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>VMware/ESXi</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -576,7 +576,7 @@
 					</div>
 				</div>
 				<div id="virtualbox" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>VirtualBox</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>VirtualBox</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -591,7 +591,7 @@
 					</div>
 				</div>
 				<div id="rockpi4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi 4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi 4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -609,7 +609,7 @@
 					</div>
 				</div>
 				<div id="zeropi" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ZeroPi</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ZeroPi</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -625,7 +625,7 @@
 					</div>
 				</div>
 				<div id="sparkysbc" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Sparky SBC (Allo)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Sparky SBC (Allo)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -647,7 +647,7 @@
 					</div>
 				</div>
 				<div id="asustinkerboard" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ASUS Tinker Board</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ASUS Tinker Board</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -665,7 +665,7 @@
 					</div>
 				</div>
 				<div id="nanopifire3" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi Fire3</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi Fire3</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -682,7 +682,7 @@
 					</div>
 				</div>
 				<div id="nanopim1plus" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1 Plus</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M1 Plus</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -700,7 +700,7 @@
 					</div>
 				</div>
 				<div id="nanopineo2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -717,7 +717,7 @@
 					</div>
 				</div>
 				<div id="nanopik1plus" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K1 Plus</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K1 Plus</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -734,7 +734,7 @@
 					</div>
 				</div>
 				<div id="nanopineo2black" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2 Black</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO2 Black</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -752,7 +752,7 @@
 					</div>
 				</div>
 				<div id="nanopim4v2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4V2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4V2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -770,7 +770,7 @@
 					</div>
 				</div>
 				<div id="pineh64" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>PINE H64</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>PINE H64</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -788,7 +788,7 @@
 					</div>
 				</div>
 				<div id="rockpro64" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCKPro64</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCKPro64</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -806,7 +806,7 @@
 					</div>
 				</div>
 				<div id="quartz64a" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model A</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model A</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -824,7 +824,7 @@
 					</div>
 				</div>
 				<div id="quartz64b" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model B</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Quartz64 Model B</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -842,7 +842,7 @@
 					</div>
 				</div>
 				<div id="soquartz" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>SOQuartz</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>SOQuartz</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -860,7 +860,7 @@
 					</div>
 				</div>
 				<div id="nativepcbios" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for BIOS/CSM</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for BIOS/CSM</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -880,7 +880,7 @@
 					</div>
 				</div>
 				<div id="rock64" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCK64</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCK64</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -899,7 +899,7 @@
 					</div>
 				</div>
 				<div id="nativepcuefi" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for UEFI</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Native PC for UEFI</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -915,7 +915,7 @@
 					</div>
 				</div>
 				<div id="otherdevice" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Other device (beta)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Other device (beta)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -931,7 +931,7 @@
 					</div>
 				</div>
 				<div id="nanopct4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPC T4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPC T4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -949,7 +949,7 @@
 					</div>
 				</div>
 				<div id="rockpis" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi S</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCK Pi S</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -967,7 +967,7 @@
 					</div>
 				</div>
 				<div id="nanopineoplus2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Plus2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO Plus2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -984,7 +984,7 @@
 					</div>
 				</div>
 				<div id="nanopim4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi M4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1002,7 +1002,7 @@
 					</div>
 				</div>
 				<div id="nanopineo4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1020,7 +1020,7 @@
 					</div>
 				</div>
 				<div id="nanopineo3" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO3</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi NEO3</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1038,7 +1038,7 @@
 					</div>
 				</div>
 				<div id="nanopir2s" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R2S</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R2S</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1056,7 +1056,7 @@
 					</div>
 				</div>
 				<div id="nanopik2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K2</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi K2</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1074,7 +1074,7 @@
 					</div>
 				</div>
 				<div id="odroidc4" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C4/HC4</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Odroid C4/HC4</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1093,7 +1093,7 @@
 				</div>
 				<!-- NanoPi R4S -->
 				<div id="nanopir4s" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R4S</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R4S</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1111,7 +1111,7 @@
 				</div>
 				<!-- NanoPi R5S/R5C -->
 				<div id="nanopir5s" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R5S/R5C</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R5S/R5C</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1130,7 +1130,7 @@
 				</div>
 				<!-- NanoPi R6S -->
 				<div id="nanopir6s" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R6S</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R6S</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1150,7 +1150,7 @@
 				</div>
 				<!-- Pinebook Pro -->
 				<div id="pinebookpro" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook Pro</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Pinebook Pro</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1169,7 +1169,7 @@
 				</div>
 				<!-- NanoPi R1 -->
 				<div id="nanopir1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R1</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>NanoPi R1</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1188,7 +1188,7 @@
 				</div>
 				<!-- Radxa Zero -->
 				<div id="radxazero" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Radxa Zero</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Radxa Zero</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1211,7 +1211,7 @@
 				</div>
 				<!-- ROCK 3A -->
 				<div id="rock3a" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 3A</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 3A</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1231,7 +1231,7 @@
 				</div>
 				<!-- ROCK 5B -->
 				<div id="rock5b" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 5B</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>ROCK 5B</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-6 project-description">
 							<div class="project-info">
@@ -1251,392 +1251,392 @@
 				</div>
 				<div id="portfolio-grid" class="row" style="display:none">
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix raspberrypi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#raspberrypi1">
+						<a href="#downloadinfo" class="thumbnail" rel="#raspberrypi1">
 							<img src="images/sbc_images/raspberrypi1.jpg" alt="Raspberry Pi 1 photo" width="8" height="5" loading="lazy">
 							<h3>Raspberry Pi 1/Zero (1)</h3>
 							<p>BCM2708 | 1 Core | ARMv6</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix raspberrypi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#raspberrypi2">
+						<a href="#downloadinfo" class="thumbnail" rel="#raspberrypi2">
 							<img src="images/sbc_images/raspberrypi2.jpg" alt="Raspberry Pi 2 photo" width="8" height="5" loading="lazy">
 							<h3>Raspberry Pi 2 PCB v1.1</h3>
 							<p>BCM2709 | 4 Cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix raspberrypi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#raspberrypi4">
+						<a href="#downloadinfo" class="thumbnail" rel="#raspberrypi4">
 							<img src="images/sbc_images/raspberrypi4.jpg" alt="Raspberry Pi 4 photo" width="8" height="5" loading="lazy">
 							<h3>Raspberry Pi 2/3/4</h3>
 							<p>BCM2710/2711 | 4 Cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix odroid">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#odroidc1">
+						<a href="#downloadinfo" class="thumbnail" rel="#odroidc1">
 							<img src="images/sbc_images/odroidc1.jpg" alt="Odroid C1 photo" width="8" height="5" loading="lazy">
 							<h3>Odroid C1</h3>
 							<p>S805 1.5GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix odroid">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#odroidc2">
+						<a href="#downloadinfo" class="thumbnail" rel="#odroidc2">
 							<img src="images/sbc_images/odroidc2.jpg" alt="Odroid C2 photo" width="8" height="5" loading="lazy">
 							<h3>Odroid C2</h3>
 							<p>S905 1.5 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix odroid">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#odroidc4">
+						<a href="#downloadinfo" class="thumbnail" rel="#odroidc4">
 							<img src="images/sbc_images/odroidc4.jpg" alt="Odroid C4 photo" width="8" height="5" loading="lazy">
 							<h3>Odroid C4/HC4</h3>
 							<p>S905X3 2 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix odroid">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#odroidn2">
+						<a href="#downloadinfo" class="thumbnail" rel="#odroidn2">
 							<img src="images/sbc_images/odroidn2.jpg" alt="Odroid N2 photo" width="8" height="5" loading="lazy">
 							<h3>Odroid N2(+)</h3>
 							<p>S922X 2.0(2.4) GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix odroid">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#odroidxu3">
+						<a href="#downloadinfo" class="thumbnail" rel="#odroidxu3">
 							<img src="images/sbc_images/odroidxu4.jpg" alt="Odroid XU4 photo" width="8" height="5" loading="lazy">
 							<h3>Odroid XU3/XU4/MC1/HC1/HC2</h3>
 							<p>Exynos5422 | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#pinea64">
+						<a href="#downloadinfo" class="thumbnail" rel="#pinea64">
 							<img src="images/sbc_images/pinea64.jpg" alt="PINE A64 photo" width="8" height="5" loading="lazy">
 							<h3>PINE A64</h3>
 							<p>A64 1.2 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#pineh64">
+						<a href="#downloadinfo" class="thumbnail" rel="#pineh64">
 							<img src="images/sbc_images/pineh64.jpg" alt="PINE H64 photo" width="8" height="5" loading="lazy">
 							<h3>PINE H64</h3>
 							<p>H6 1.488 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#pinebook">
+						<a href="#downloadinfo" class="thumbnail" rel="#pinebook">
 							<img src="images/sbc_images/pinebook.jpg" alt="Pinebook photo" width="8" height="5" loading="lazy">
 							<h3>Pinebook</h3>
 							<p>A64 1.1 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#pinebookpro">
+						<a href="#downloadinfo" class="thumbnail" rel="#pinebookpro">
 							<img src="images/sbc_images/pinebookpro.jpg" alt="Pinebook Pro photo" width="8" height="5" loading="lazy">
 							<h3>Pinebook Pro</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rock64">
+						<a href="#downloadinfo" class="thumbnail" rel="#rock64">
 							<img src="images/sbc_images/rock64.jpg" alt="ROCK64 photo" width="8" height="5" loading="lazy">
 							<h3>ROCK64</h3>
 							<p>RK3328 1.3GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rockpro64">
+						<a href="#downloadinfo" class="thumbnail" rel="#rockpro64">
 							<img src="images/sbc_images/rockpro64.jpg" alt="ROCKPro64 photo" width="8" height="5" loading="lazy">
 							<h3>ROCKPro64</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#quartz64a">
+						<a href="#downloadinfo" class="thumbnail" rel="#quartz64a">
 							<img src="images/sbc_images/quartz64a.jpg" alt="Quartz64 Model A photo" width="8" height="5" loading="lazy">
 							<h3>Quartz64 Model A</h3>
 							<p>RK3566 1.8GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#quartz64b">
+						<a href="#downloadinfo" class="thumbnail" rel="#quartz64b">
 							<img src="images/sbc_images/quartz64b.jpg" alt="Quartz64 Model B photo" width="8" height="5" loading="lazy">
 							<h3>Quartz64 Model B</h3>
 							<p>RK3566 1.8GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix pine">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#soquartz">
+						<a href="#downloadinfo" class="thumbnail" rel="#soquartz">
 							<img src="images/sbc_images/soquartz.jpg" alt="SOQuartz photo" width="8" height="5" loading="lazy">
 							<h3>SOQuartz</h3>
 							<p>RK3566 1.8GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix radxa">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rockpi4">
+						<a href="#downloadinfo" class="thumbnail" rel="#rockpi4">
 							<img src="images/sbc_images/rockpi4.jpg" alt="ROCK Pi 4 photo" width="8" height="5" loading="lazy">
 							<h3>ROCK Pi 4</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix radxa">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rockpis">
+						<a href="#downloadinfo" class="thumbnail" rel="#rockpis">
 							<img src="images/sbc_images/rockpis.jpg" alt="ROCK Pi S photo" width="8" height="5" loading="lazy">
 							<h3>ROCK Pi S</h3>
 							<p>RK3308 | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix radxa">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#radxazero">
+						<a href="#downloadinfo" class="thumbnail" rel="#radxazero">
 							<img src="images/sbc_images/radxazero.jpg" alt="Radxa Zero photo" width="8" height="5" loading="lazy">
 							<h3>Radxa Zero</h3>
 							<p>S905Y2 1.8GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix radxa">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rock3a">
+						<a href="#downloadinfo" class="thumbnail" rel="#rock3a">
 							<img src="images/sbc_images/rock3a.jpg" alt="ROCK 3A photo" width="8" height="5" loading="lazy">
 							<h3>ROCK 3A</h3>
 							<p>RK3568 | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix radxa">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#rock5b">
+						<a href="#downloadinfo" class="thumbnail" rel="#rock5b">
 							<img src="images/sbc_images/rock5b.jpg" alt="ROCK 5B photo" width="8" height="5" loading="lazy">
 							<h3>ROCK 5B</h3>
 							<p>RK3588 2.4GHz | 8 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix allo">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#sparkysbc">
+						<a href="#downloadinfo" class="thumbnail" rel="#sparkysbc">
 							<img src="images/sbc_images/sparkysbc.jpg" alt="Sparky SBC photo" width="8" height="5" loading="lazy">
 							<h3>Sparky SBC (Allo)</h3>
 							<p>1.1GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix asus">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#asustinkerboard">
+						<a href="#downloadinfo" class="thumbnail" rel="#asustinkerboard">
 							<img src="images/sbc_images/asustinkerboard.jpg" alt="ASUS Tinker Board photo" width="8" height="5" loading="lazy">
 							<h3>ASUS Tinker Board</h3>
 							<p>RK3288 1.8GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopct4">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopct4">
 							<img src="images/sbc_images/nanopct4.jpg" alt="NanoPC T4 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPC T4</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim4">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim4">
 							<img src="images/sbc_images/nanopim4.jpg" alt="NanoPi M4 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M4</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineo4">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineo4">
 							<img src="images/sbc_images/nanopineo4.jpg" alt="NanoPi NEO4 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO4</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim4v2">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim4v2">
 							<img src="images/sbc_images/nanopim4v2.jpg" alt="NanoPi M4V2 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M4V2</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopir4s">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopir4s">
 							<img src="images/sbc_images/nanopir4s.jpg" alt="NanoPi R4S photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi R4S</h3>
 							<p>RK3399 1.8GHz | 6 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopir5s">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopir5s">
 							<img src="images/sbc_images/nanopir5s.jpg" alt="NanoPi R5S photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi R5S/R5C</h3>
 							<p>RK3568 2.0GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopir6s">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopir6s">
 							<img src="images/sbc_images/nanopir6s.jpg" alt="NanoPi R6S photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi R6S</h3>
 							<p>RK3588 2.4GHz | 8 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#zeropi">
+						<a href="#downloadinfo" class="thumbnail" rel="#zeropi">
 							<img src="images/sbc_images/zeropi.jpg" alt="ZeroPi photo" width="8" height="5" loading="lazy">
 							<h3>ZeroPi</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineo">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineo">
 							<img src="images/sbc_images/nanopineo.jpg" alt="NanoPi NEO photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineoair">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineoair">
 							<img src="images/sbc_images/nanopineoair.jpg" alt="NanoPi NEO Air photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO Air</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineo2">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineo2">
 							<img src="images/sbc_images/nanopineo2.jpg" alt="NanoPi NEO2 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO2</h3>
 							<p>H5 1.2 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineo2black">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineo2black">
 							<img src="images/sbc_images/nanopineo2black.jpg" alt="NanoPi NEO2 Black photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO2 Black</h3>
 							<p>H5 1.2 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineoplus2">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineoplus2">
 							<img src="images/sbc_images/nanopineoplus2.jpg" alt="NanoPi NEO Plus2 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO Plus2</h3>
 							<p>H5 1.2 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopineo3">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopineo3">
 							<img src="images/sbc_images/nanopineo3.jpg" alt="NanoPi NEO3 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi NEO3</h3>
 							<p>RK3328 1.5 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopir2s">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopir2s">
 							<img src="images/sbc_images/nanopir2s.jpg" alt="NanoPi R2S photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi R2S</h3>
 							<p>RK3328 1.5 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopik1plus">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopik1plus">
 							<img src="images/sbc_images/nanopik1plus.jpg" alt="NanoPi K1 Plus photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi K1 Plus</h3>
 							<p>H5 1.4 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopik2">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopik2">
 							<img src="images/sbc_images/nanopik2.jpg" alt="NanoPi K2 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi K2</h3>
 							<p>S905 1.5 GHz | 4 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim1">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim1">
 							<img src="images/sbc_images/nanopim1.jpg" alt="NanoPi M1 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M1</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim1plus">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim1plus">
 							<img src="images/sbc_images/nanopim1plus.jpg" alt="NanoPi M1 Plus photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M1 Plus</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopir1">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopir1">
 							<img src="images/sbc_images/nanopir1.jpg" alt="NanoPi R1 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi R1</h3>
 							<p>H3 1.2 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim2">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim2">
 							<img src="images/sbc_images/nanopim2.jpg" alt="NanoPi M2 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M2/T2</h3>
 							<p>S5P4418 1.4 GHz | 4 cores | ARMv7</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopim3">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopim3">
 							<img src="images/sbc_images/nanopim3.jpg" alt="NanoPi M3 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi M3/T3</h3>
 							<p>S5P6818 1.4 GHz | 8 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix nanopi">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nanopifire3">
+						<a href="#downloadinfo" class="thumbnail" rel="#nanopifire3">
 							<img src="images/sbc_images/nanopifire3.jpg" alt="NanoPi Fire3 photo" width="8" height="5" loading="lazy">
 							<h3>NanoPi Fire3</h3>
 							<p>S5P6818 1.4 GHz | 8 cores | ARMv8</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nativepcbios">
+						<a href="#downloadinfo" class="thumbnail" rel="#nativepcbios">
 							<img src="images/sbc_images/nativepc.jpg" alt="PC logo" width="8" height="5" loading="lazy">
 							<h3>Native PC (BIOS/CSM)</h3>
 							<p>x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#nativepcuefi">
+						<a href="#downloadinfo" class="thumbnail" rel="#nativepcuefi">
 							<img src="images/sbc_images/nativepc.jpg" alt="PC logo" width="8" height="5" loading="lazy">
 							<h3>Native PC (UEFI)</h3>
 							<p>x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#vmware">
+						<a href="#downloadinfo" class="thumbnail" rel="#vmware">
 							<img src="images/sbc_images/vmware.jpg" alt="VMware logo" width="8" height="5" loading="lazy">
 							<h3>VMware/ESXi</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#virtualbox">
+						<a href="#downloadinfo" class="thumbnail" rel="#virtualbox">
 							<img src="images/sbc_images/virtualbox.jpg" alt="VirtualBox logo" width="8" height="5" loading="lazy">
 							<h3>VirtualBox</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#proxmox">
+						<a href="#downloadinfo" class="thumbnail" rel="#proxmox">
 							<img src="images/sbc_images/proxmox.svg" alt="Proxmox logo" width="8" height="5" loading="lazy">
 							<h3>Proxmox</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#hyperv">
+						<a href="#downloadinfo" class="thumbnail" rel="#hyperv">
 							<img src="images/sbc_images/hyperv.jpg" alt="Hyper-V logo" width="8" height="5" loading="lazy">
 							<h3>Hyper-V</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#parallels">
+						<a href="#downloadinfo" class="thumbnail" rel="#parallels">
 							<img src="images/sbc_images/parallels.svg" alt="Parallels logo" width="8" height="5" loading="lazy">
 							<h3>Parallels</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix x86_64">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#utm">
+						<a href="#downloadinfo" class="thumbnail" rel="#utm">
 							<img src="images/sbc_images/utm.png" alt="UTM logo" width="8" height="5" loading="lazy">
 							<h3>UTM</h3>
 							<p>Virtual Machine x86_64</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix other">
-						<a href="#downloadinfo" class="thumbnail show_hide" rel="#otherdevice">
+						<a href="#downloadinfo" class="thumbnail" rel="#otherdevice">
 							<img src="images/sbc_images/otherdevice.jpg" alt="Question mark" width="8" height="5" loading="lazy">
 							<h3>Other device?</h3>
 							<p>Convert into DietPi system</p>
@@ -1767,7 +1767,7 @@
 		<a class="scrollup" href="#"><svg viewBox="0 0 12 12"><path d="M1 8l5-5l5 5"/></svg></a>
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
+			for (let x of document.querySelectorAll('div.single-project')) x.classList.add('hidden');
 			document.getElementById("downloadinfo").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,6 @@
 // https://github.com/MichaIng/DietPi-Website
 'use strict';
 !function () {
-	// Initialise home slider: https://github.com/Le-Stagiaire/jquery.cslider
-	// Check first if function exist to allow skipping it on dietpi-software site
-	if (typeof $.fn.cslider === 'function')
-		$('#home').cslider();
-
 	// Store used elements globally once
 	var lastId,
 	    scrollUp = document.querySelector('a.scrollup'),
@@ -57,9 +52,9 @@
 
 		// Display or hide scroll-to-top button
 		if (window.pageYOffset > 80) {
-			scrollUp.style.opacity = 100;
+			scrollUp.style.opacity = '1';
 		} else {
-			scrollUp.style.opacity = 0;
+			scrollUp.style.opacity = '0';
 		}
 	});
 
@@ -80,35 +75,25 @@
 	});
 
 	// Show or hide portfolio description on click
-	for (let x of document.querySelectorAll('.show_hide')) {
+	for (let x of document.querySelectorAll('.close, .thumbnail')) {
 		x.addEventListener('click', function () {
-			$('div.single-project').slideUp(500, '');
-			$(x.getAttribute('rel')).slideToggle(500, '');
+			let target = document.querySelector(x.getAttribute('rel'));
+			for (let x of singleProjects) {
+				if (x === target) {
+					x.style.height = x.scrollHeight + 'px';
+					x.classList.remove('hidden');
+				} else if (x.clientHeight) {
+					x.style.height = '0';
+					x.classList.add('hidden');
+				}
+			}
 		});
 	}
 
-	// Function for smooth scrolling links
+	// Collapse navbar when clicking page anchor
 	for (let x of document.querySelectorAll('a[href^="#"]')) {
-		// Scroll to top offset
-		let target, targetOffset;
-		if (x.hash === '') {
-			targetOffset = 0;
-		// Scroll target
-		} else {
-			target = document.getElementById(x.hash.substring(1));
-		}
 		x.addEventListener('click', function () {
-			// Collapse navbar when scrolling
 			navbar.classList.remove('show');
-			// Get section offset
-			if (target)
-				targetOffset = window.pageYOffset + target.getBoundingClientRect().y - navbarHeight;
-			// Scroll in 0.75 seconds
-			$('html, body').animate({
-				scrollTop: targetOffset
-			}, 750);
-			// Omit browser link processing
-			return false;
 		});
 	}
 }();

--- a/js/jquery.cslider.js
+++ b/js/jquery.cslider.js
@@ -156,4 +156,5 @@
         }
         return this;
     };
+    $('#home').cslider();
 }();

--- a/stats.html
+++ b/stats.html
@@ -35,7 +35,6 @@
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css?v=2">
 		<link rel="stylesheet" type="text/css" href="css/style.min.css?v=7">
 		<!-- Include JavaScript -->
-		<script defer src="js/jquery.min.js"></script>
 		<script defer src="js/bootstrap.min.js?v=2"></script>
 		<script defer src="js/mixitup.min.js"></script>
 		<script defer src="js/app.min.js?v=1"></script>
@@ -76,7 +75,7 @@
 					<button class="nav-link filter" data-filter=".debian">Debian</button>
 				</nav>
 				<div id="commands" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>Commands to derive data</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>Commands to derive data</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -97,7 +96,7 @@
 					</div>
 				</div>
 				<div id="raspberrypios1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (32-bit)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (32-bit)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -121,7 +120,7 @@
 					</div>
 				</div>
 				<div id="raspberrypios2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (64-bit)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Raspberry Pi OS Lite (64-bit)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -145,7 +144,7 @@
 					</div>
 				</div>
 				<div id="armbian1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -169,7 +168,7 @@
 					</div>
 				</div>
 				<div id="armbian2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -193,7 +192,7 @@
 					</div>
 				</div>
 				<div id="armbian3" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Armbian (server image)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -217,7 +216,7 @@
 					</div>
 				</div>
 				<div id="debian1" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -241,7 +240,7 @@
 					</div>
 				</div>
 				<div id="debian2" class="single-project">
-					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="show_hide close"></span></div></div>
+					<div class="row"><div class="col-md-12 project-title"><h3>DietPi vs Debian (server image)</h3><span class="close"></span></div></div>
 					<div class="row">
 						<div class="col-md-12 project-description">
 							<div class="project-info">
@@ -265,56 +264,56 @@
 				</div>
 				<div id="portfolio-grid" class="row" style="display:none">
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix commands">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#commands">
+						<a href="#distrostats" class="thumbnail" rel="#commands">
 							<img src="images/stats/commands.svg" alt="Linux command prompt sign" width="8" height="5" loading="lazy">
 							<h3>Test commands</h3>
 							<p>Commands to obtain system stats</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix raspberrypios">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#raspberrypios1">
+						<a href="#distrostats" class="thumbnail" rel="#raspberrypios1">
 							<img src="images/stats/raspberrypios.svg" alt="Raspberry Pi OS logo" width="8" height="5" loading="lazy">
 							<h3>Raspberry Pi OS Lite</h3>
 							<p>on Raspberry Pi 2 (32-bit)</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix raspberrypios">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#raspberrypios2">
+						<a href="#distrostats" class="thumbnail" rel="#raspberrypios2">
 							<img src="images/stats/raspberrypios.svg" alt="Raspberry Pi OS logo" width="8" height="5" loading="lazy">
 							<h3>Raspberry Pi OS Lite</h3>
 							<p>on Raspberry Pi 4 (64-bit)</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix armbian">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#armbian1">
+						<a href="#distrostats" class="thumbnail" rel="#armbian1">
 							<img src="images/stats/armbian.png" alt="Armbian logo" width="8" height="5" loading="lazy">
 							<h3>Armbian</h3>
 							<p>on NanoPi R2S</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix armbian">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#armbian2">
+						<a href="#distrostats" class="thumbnail" rel="#armbian2">
 							<img src="images/stats/armbian.png" alt="Armbian logo" width="8" height="5" loading="lazy">
 							<h3>Armbian</h3>
 							<p>on Odroid C4</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix armbian">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#armbian3">
+						<a href="#distrostats" class="thumbnail" rel="#armbian3">
 							<img src="images/stats/armbian.png" alt="Armbian logo" width="8" height="5" loading="lazy">
 							<h3>Armbian</h3>
 							<p>on NanoPi NEO3</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix debian">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#debian1">
+						<a href="#distrostats" class="thumbnail" rel="#debian1">
 							<img src="images/stats/debian.svg" alt="Debian logo" width="8" height="5" loading="lazy">
 							<h3>Debian</h3>
 							<p>on Odroid C4</p>
 						</a>
 					</div>
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix debian">
-						<a href="#distrostats" class="thumbnail show_hide" rel="#debian2">
+						<a href="#distrostats" class="thumbnail" rel="#debian2">
 							<img src="images/stats/debian.svg" alt="Debian logo" width="8" height="5" loading="lazy">
 							<h3>Debian</h3>
 							<p>on x86_64 PC</p>
@@ -352,7 +351,7 @@
 		<!-- Scroll up button end -->
 		<!-- Inline JavaScript to quickly show/hide elements if browser loads scripts -->
 		<script>
-			document.querySelectorAll('div.single-project').forEach(function(e){e.setAttribute("style","display:none");});
+			for (let x of document.querySelectorAll('div.single-project')) x.classList.add('hidden');
 			document.getElementById("distrostats").removeAttribute("style");
 			document.getElementById("portfolio-grid").removeAttribute("style");
 		</script>


### PR DESCRIPTION
- Use native browser smooth scrolling
- Toggle detail frames via "hidden" class
- Remove obsolete "show_hide" class
- Fix little issue with .5 marging and padding not being handled correctly: The navbar is exactly 60px high now with 50px high elements.
- Load jQuery only on `index.html` where the slider is used as last part that requires it

Again very similar to #251.

- Native browser smooth scrolling does not work on Windows if "Animate controls and elements inside windows" is disabled in system performance settings: https://stackoverflow.com/a/73546487/16145737
- It can be however overwritten by enabling a respective flag in Chromium-based browsers: https://stackoverflow.com/a/67124806/16145737
- Else it should be fine to not scroll smoothly since obviously the user chose avoid unnecessary animations.

EDIT: Little pitfall with `transition: height 0.5`:
- The transition only works if original and target height are absolute values. If height is not set or set to `auto` or similar, it is switched immediately.
- The workaround was already applied in #251 and I did a mix of this + classed based toggle in a way which does not require setting specific style values (like `margin-bottom: 30px`) in JavaScript.