### PR TITLE
Fix WordPress letter casing

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -409,7 +409,7 @@ Widevine
 wifi
 WireGuard
 WiringPi
-Wordpress
+WordPress
 WPA
 www
 Xfce

--- a/dietpi-software.html
+++ b/dietpi-software.html
@@ -1286,11 +1286,11 @@
 				</div>
 				<!-- Start details for portfolio project 63 -->
 				<div id="slidingdiv63" class="row single-project">
-					<div class="col-md-4"><a href="images/dietpi-software/wordpress_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/wordpress_1.jpg" alt="Wordpress" loading="lazy"></a></div>
+					<div class="col-md-4"><a href="images/dietpi-software/wordpress_2.jpg" target="_blank" rel="noopener"><img src="images/dietpi-software/wordpress_1.jpg" alt="WordPress" loading="lazy"></a></div>
 					<div class="col-md-8">
 						<div class="project-description">
 							<div class="project-title clearfix">
-								<h3>Wordpress</h3>
+								<h3>WordPress</h3>
 								<span class="close"></span>
 							</div>
 							<div class="project-info">
@@ -2780,7 +2780,7 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins <
 					<div class="col-xl-2 col-lg-3 col-md-4 col-6 mix Social">
 						<a href="#softwareinfo" class="thumbnail" rel="#slidingdiv63">
 							<img src="images/dietpi-software/wordpress_0.jpg" alt="project 63" width="8" height="5" loading="lazy">
-							<h3>Wordpress</h3>
+							<h3>WordPress</h3>
 							<p>Blog and Publishing platform</p>
 						</a>
 					</div>


### PR DESCRIPTION
Updates the letter casing for WordPress string in headings and text, as per [brand guidelines](https://make.wordpress.org/marketing/handbook/resources/style-guide-and-brand-book/#writing-about-wordpress).