### PR TITLE
Switch all image downlods to Bookworm

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -313,6 +313,7 @@ Raspotify
 Rclone
 RDP
 Readarr
+rebased
 Reclocker
 ReadyMedia
 RealVNC

--- a/index.html
+++ b/index.html
@@ -232,15 +232,19 @@
 								<div><span>CPU:</span>BCM2708 900/1000 MHz | 1 Core | ARMv6</div>
 								<div><span>RAM:</span>256 MiB - 512 MiB LPDDR2</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
+								</div>
+								<div>
+									<span>Bookworm images:</span>
+									<br>We provide images based on the new Debian Bookworm release as well, but those are currently not able to run PHP. All info about this, and how to install the new images regardless, can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
 								</div>
 							</div>
 							<p>These images are compatible with all Raspberry Pi models, but we recommend it only for Raspberry Pi 1 and Zero (1) models.</p>
@@ -265,6 +269,10 @@
 								<div>
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
+								</div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
 								</div>
 							</div>
 							<p>
@@ -293,6 +301,10 @@
 									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
 								</div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>
 								These images are compatible with all Raspberry Pi 3 and 4 models, as well as Raspberry Pi 2 PCB v1.2 and Zero 2.
@@ -316,6 +328,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Odroid C1 is esteemed to be the most powerful low-cost single board computer available, as well as being an extremely versatile device. Featuring a quad-core Amlogic processor, advanced Mali GPU, and Gigabit Ethernet, it can function as a home theater set-top box, a general purpose computer for web browsing, gaming and socializing, a compact tool for college or office work, a prototyping device for hardware tinkering, a controller for home automation, a workstation for software development, and much more.</p>
 						</div>
@@ -332,6 +348,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>In our eyes, the Odroid C2 is the best "all round" SBC on the market today. Exceptional CPU and LAN performance which is great for multiple uses. Couple the C2 with an eMMC module and you'll experience next-level SBC filesystem performance at up to 140 MiB/s transfer rates. The C2 is innovative SBC perfection, and, because of its excellent all round performance, we even have a few dedicated to daily DietPi testing.</p>
 						</div>
@@ -348,6 +368,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidXU4-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The XU4 is a powerhouse performance monster SBC and features USB 3.0, which makes it great for a NAS system. However, the XU4 does suffer from excessive heat at full load, you can expect 3-5 seconds at full load, before thermal throttling kicks in @ 95 °C and reduces clocks. Aside from this, the XU4 is one of the most powerful SBC on the market today and features a much welcomed USB 3.0 support. It also looks great with Odroid-CloudShell and DietPi-CloudShell stats!</p>
 						</div>
@@ -365,6 +389,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEA64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>PINE A64 was the worlds first "kickstarted" SBC (AFAIK). Featuring a 64-bit CPU and up to 2 GiB RAM with Gbit Ethernet. The PINE A64 shows promise for future kickstarted SBCs, albeit, the PINE A64 board is somewhat cumbersome.</p>
 						</div>
@@ -382,6 +410,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Small SBC with lots of features.</p>
 						</div>
@@ -400,6 +432,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOAir-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Small SBC with lots of features.</p>
 						</div>
@@ -417,6 +453,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Small SBC with lots of features.</p>
 						</div>
@@ -469,6 +509,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Pinebook-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Pinebook is a phenomenal Linux laptop with exceptional build quality that rivals £300+ laptops. The unit is fitted with an exceptionally bright 1080p IPS screen, eMMC and onboard WiFi.</p>
 							<p>When considering all this only costs $99, you'd be silly not to pick one up. Highly recommended for anyone who loves SBCs with an expected light workload use. An ARM laptop done right, and then some!</p>
@@ -487,6 +531,7 @@
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Hyper-V virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
+							<p>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.</p>
 						</div>
 						<div class="col-md-6"><img src="images/sbc_images/hyperv.jpg" alt="Hyper-V logo" width="8" height="5" loading="lazy"></div>
 					</div>
@@ -500,6 +545,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Parallels virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 						</div>
@@ -515,6 +564,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The UTM virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 						</div>
@@ -530,6 +583,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Proxmox virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 						</div>
@@ -548,6 +605,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidN2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Hardkernel's next generation "high-end" SBC is finally here! The fastest ARM SBC we have ever tested. Excellent performance and thermals at a reasonable price range.</p>
 						</div>
@@ -570,6 +631,10 @@
 									<br>This appliance can be used with <b>VMware vSphere</b> and <b>ESXi</b>.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The VMware virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 						</div>
@@ -585,6 +650,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The VirtualBox virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 						</div>
@@ -603,6 +672,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPi4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Compared to other RK3399 SBCs, this one is small sized, like the Raspberry Pi.</p>
 						</div>
@@ -620,6 +693,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ZeroPi-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 						</div>
 						<div class="col-md-6"><img src="images/sbc_images/zeropi.jpg" alt="ZeroPi photo" width="8" height="5" loading="lazy"></div>
@@ -659,6 +736,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ASUSTB-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Here come the giants "ASUS" with their first SBC on the market. It provides excellent performance as a SBC with its 1.8 GHz CPU and SDIO 3.0 for fast SD transfer rates. The S model contains an additional onboard eMMC module with write speeds of 70 MiB/s and read speeds of 150 MiB/s. A highly recommended SBC.</p>
 						</div>
@@ -694,6 +775,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1Plus-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Small SBC with lots of features.</p>
 						</div>
@@ -711,6 +796,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>An upgrade to the original Nano NEO, now features H5 64-bit CPU and Gbit LAN. Quite possibly the smallest (and cutest) SBC on the market. Great for headless/IoT/NAS/server/HiFi projects and showing old friends how small computers have become.</p>
 						</div>
@@ -728,6 +817,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK1Plus-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A direct competitor to the RPi 3+. Features excellent and stable onboard WiFi, 64-bit CPU. A great all round board, utilizing the H5 ARM CPU. A good alternative to the RPi 3+, with increased performance at a similar price range.</p>
 						</div>
@@ -746,6 +839,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2Black-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A NEO2 upgrade with some additional features like eMMC and available with 1 GiB RAM</p>
 						</div>
@@ -764,6 +861,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4V2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>New build of the NanoPi M4 with DDR4 instead of DDR3 RAM.</p>
 						</div>
@@ -782,6 +883,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEH64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The PINE H64 is available in two variants, Model A with larger PCB, PCIe slot and optional WiFi, and Model B with ROCK64-size PCB, without PCIe slot and fixed onboard WiFi.</p>
 						</div>
@@ -800,6 +905,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPro64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The ROCK64's big brother is here! One of the fastest ARM SBC (RK3399) on the market today, with 2x1.8 GHz A72 cores and 4x1.4 GHz A53 cores. Onboard full size PCIe x4 with excellent throughput compliments a NAS/Server setup, and, endless opportunities. A great addition to your SBC lineup that provides next gen SBC performance. Bottom line: "it's a little chunky, but it ain't no monkey", we love it!</p>
 						</div>
@@ -818,6 +927,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64A-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>PINE64's next generation SBC based on the new Rockchip RK3566 SoC, which provides a lot of hardware features and connectors. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the SBC.</p>
 						</div>
@@ -836,6 +949,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64B-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>PINE64's next generation SBC in credit card size, based on the new Rockchip RK3566 SoC, which provides a lot of hardware features and connectors. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the SBC.</p>
 						</div>
@@ -854,6 +971,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_SOQuartz-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>PINE64's next generation compute module based on the new Rockchip RK3566 SoC, which provides a lot of hardware features. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the default baseboard.</p>
 						</div>
@@ -874,6 +995,10 @@
 									<br>Choose this to write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Native PC is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience. This image is for motherboards with BIOS and/or CSM boot support.</p>
 						</div>
@@ -893,6 +1018,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A welcomed evolution of the PINE64 is finally here. Reduced PCB size, low cost, USB 3.0, Gbit Ethernet and eMMC option. A worthy SBC for any server/NAS project.</p>
 						</div>
@@ -909,6 +1038,10 @@
 									<br>Write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The Native PC is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience. This image is for motherboards with UEFI boot support and onboard EMMC (e.g.: Z83-II, Beelink AP32 and other Intel NUC/SBC devices with onboard eMMC).</p>
 						</div>
@@ -943,6 +1076,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPCT4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>FriendlyELEC's next generation SBC is finally here! One of the fastest ARM SBC (RK3399) on the market today, with 2x1.8 GHz A72 cores and 4x1.4 GHz A53 cores. Onboard M.2/PCIe x4 with excellent throughput compliments a NAS/Server setup. Bottom line, we love it!</p>
 						</div>
@@ -961,6 +1098,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPiS-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Little brother of the ROCK Pi 4, headless but with voice detection engine, for IoT and voice applications.</p>
 						</div>
@@ -979,6 +1120,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOPlus2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 						</div>
 						<div class="col-md-6"><img src="images/sbc_images/nanopineoplus2.jpg" alt="NanoPi NEO Plus2 photo" width="8" height="5" loading="lazy"></div>
@@ -996,6 +1141,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Little brother of the NanoPC T4 with same SoC (RK3399) performance but a few less features, like no onboard eMMC chip (but socket) and no M.2 socket. However the form factor is RPi-like which might suite certain use-cases.</p>
 						</div>
@@ -1014,6 +1163,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The smallest board of the M4/T4/NEO4 RK3399 family. One gets full RK3399 SoC power on a tiny form factor but pays this with only 1 GB RAM and the loss of the 3.5mm audio jack (HDMI audio only) compared to the M4.</p>
 						</div>
@@ -1032,6 +1185,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO3-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A tiny headless SBC, comes in a cute white housing with fanless cooling. It has the ROCK64 SoC, so you know what you can expect, but it runs hot quickly inside there. Prepare to limit the maximum CPU frequency, apply a strict GPU governor or put the board into a new cool well ventilated home.</p>
 						</div>
@@ -1050,6 +1207,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR2S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A headless dual-Ethernet SBC, useful as router setup or network bridge. It has the ROCK64 SoC, so you know what you can expect.</p>
 						</div>
@@ -1068,6 +1229,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>A well featured SBC with the SoC that one might know from Odroid C2</p>
 						</div>
@@ -1086,6 +1251,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Odroid C2 successor with modern upgraded components.</p>
 						</div>
@@ -1104,6 +1273,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR4S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>FriendlyELEC's RK3399 dual-Ethernet/router board. When using the optionally shipped metal case, the CPU temperature stays in moderate range without a fan, as long as you do not run long-term full-load processes. It is purely headless but has a serial/UART debug port, so if you use it for important services, we recommend to have a serial terminal or adapter cable available, to allow console access even in case of boot issues of failing network (no SSH).</p>
 						</div>
@@ -1123,6 +1296,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR5S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>FriendlyELEC's latest RK3568 dual-2.5 Gbit Ethernet router board. When using the optionally shipped metal case, the CPU temperature stays in moderate range without a fan, as long as you do not run long-term full-load processes. Other than previous NanoPi router boards, the R5S has a HDMI port as well.</p>
 						</div>
@@ -1143,6 +1320,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR6S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>FriendlyELEC's new flagship mini router SBC, featuring the new Rockchip RK3588 SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>
 						</div>
@@ -1162,6 +1343,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_PinebookPro-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The RK3399-based successor of the previous A64-based Pinebook.</p>
 						</div>
@@ -1181,6 +1366,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>The smallest dual-Ethernet SBC we currently support. This image should run on NanoPi R1S-H3 as well, which is pretty similar, just without eMMC and one USB port only.</p>
 						</div>
@@ -1201,6 +1390,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_RadxaZero-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Radxa Zero features a quad core 64-bit ARM processor, 32bit LPDDR4, up to 4K@60 HDMI, 802.11ac WiFi, Bluetooth 5.0, USB 3.0, 40-pin GPIO header. Radxa Zero supports USB 2.0 OTG and power via one USB C port.
 								<br>Radxa Zero comes in 4 options with different RAM/storage configuration.
@@ -1224,6 +1417,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK3A-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Radxa's new mid-range SBC, featuring the new Rockchip RK3568 SoC with 4x Cortex A55 CPU @2.0 GHz</p>
 						</div>
@@ -1244,6 +1441,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK5B-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Radxa's new flagship SBC, featuring the new Rockchip RK3588 SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>
 						</div>
@@ -1264,6 +1465,10 @@
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_OrangePi5-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div>
+									<span>Bullseye images:</span>
+									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
+								</div>
 							</div>
 							<p>Orange pi new flagship SBC, featuring the new Rockchip RK3588S SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>
 						</div>

--- a/index.html
+++ b/index.html
@@ -66,10 +66,10 @@
 				<svg class="triangle" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M0 0h100l-50 100"/></svg>
 				<!-- Slide 1 -->
 				<div class="da-slide da-slide-current">
-					<h2>DietPi v8.18 has been released</h2>
-					<h4>Check out all changes</h4>
-					<p>Linux 6.3, LVM and RAID support for Quartz64, Pi-hole support for RISC-V, lots of fixes for Debian Bookworm, preparing for its release on 2023-06-10.</p>
-					<a class="da-link" href="https://dietpi.com/docs/releases/v8_18/" target="_blank" rel="noopener">Release notes</a>
+					<h2>Debian Bookworm has been released</h2>
+					<h4>All info about the new Debian release</h4>
+					<p>Debian Bookworm has been released on 2023-06-10. Most image downloads have been rebased onto Bookworm, but we still provide Bullseye images as well. Find all relevant info in our article:</p>
+					<a class="da-link" href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">All info</a>
 					<div class="da-img"><img class="img-fluid" src="images/dietpi-logo_360x360.png" alt="DietPi logo" width="300" height="300" loading="lazy"></div>
 				</div>
 				<!-- Slide 2 -->

--- a/index.html
+++ b/index.html
@@ -232,14 +232,14 @@
 								<div><span>CPU:</span>BCM2708 900/1000 MHz | 1 Core | ARMv6</div>
 								<div><span>RAM:</span>256 MiB - 512 MiB LPDDR2</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bullseye_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv6-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
 								</div>
 							</div>
@@ -256,14 +256,14 @@
 								<div><span>CPU:</span>BCM2709 900 MHz | 4 Cores | ARMv7</div>
 								<div><span>RAM:</span>1 GiB LPDDR2</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bullseye_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv7-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
 								</div>
 							</div>
@@ -283,14 +283,14 @@
 								<div><span>CPU:</span>BCM2710/2711 900-1800 MHz | 4 Cores | ARMv8</div>
 								<div><span>RAM:</span>1 GiB LPDDR2 - 8 GiB LPDDR4</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm_Amiberry.7z"><span>Amiberry image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image installs and boots into <a href="https://dietpi.com/docs/software/gaming/#amiberry" target="_blank" rel="noopener" style="text-decoration-line:underline;">Amiberry</a> automatically on first boot.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bookworm_AlloGUI.7z"><span>Allo GUI image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This image has our <a href="https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523" target="_blank" rel="noopener" style="text-decoration-line:underline;">Allo web GUI</a> and audiophile software pre-installed.
 								</div>
 							</div>
@@ -314,7 +314,7 @@
 									<span></span>No eMMC support, limited USB hot-plug support
 								</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC1-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Odroid C1 is esteemed to be the most powerful low-cost single board computer available, as well as being an extremely versatile device. Featuring a quad-core Amlogic processor, advanced Mali GPU, and Gigabit Ethernet, it can function as a home theater set-top box, a general purpose computer for web browsing, gaming and socializing, a compact tool for college or office work, a prototyping device for hardware tinkering, a controller for home automation, a workstation for software development, and much more.</p>
@@ -330,7 +330,7 @@
 								<div><span>CPU:</span>Amlogic S905 1.54 GHz | 4 cores | ARMv8</div>
 								<div><span>RAM:</span>2 GiB DDR3</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>In our eyes, the Odroid C2 is the best "all round" SBC on the market today. Exceptional CPU and LAN performance which is great for multiple uses. Couple the C2 with an eMMC module and you'll experience next-level SBC filesystem performance at up to 140 MiB/s transfer rates. The C2 is innovative SBC perfection, and, because of its excellent all round performance, we even have a few dedicated to daily DietPi testing.</p>
@@ -346,7 +346,7 @@
 								<div><span>CPU:</span>Samsung Exynos5422 2.0/1.4 GHz | 8 cores | ARMv8</div>
 								<div><span>RAM:</span>2 GiB DDR3</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidXU4-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidXU4-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The XU4 is a powerhouse performance monster SBC and features USB 3.0, which makes it great for a NAS system. However, the XU4 does suffer from excessive heat at full load, you can expect 3-5 seconds at full load, before thermal throttling kicks in @ 95 °C and reduces clocks. Aside from this, the XU4 is one of the most powerful SBC on the market today and features a much welcomed USB 3.0 support. It also looks great with Odroid-CloudShell and DietPi-CloudShell stats!</p>
@@ -363,7 +363,7 @@
 								<div><span>RAM:</span>512 MiB - 2 GiB DDR3</div>
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEA64-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEA64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>PINE A64 was the worlds first "kickstarted" SBC (AFAIK). Featuring a 64-bit CPU and up to 2 GiB RAM with Gbit Ethernet. The PINE A64 shows promise for future kickstarted SBCs, albeit, the PINE A64 board is somewhat cumbersome.</p>
@@ -380,7 +380,7 @@
 								<div><span>RAM:</span>256 MiB - 512 MiB DDR3</div>
 								<div><span>NET:</span>100 Mbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Small SBC with lots of features.</p>
@@ -398,7 +398,7 @@
 								<div><span>NET:</span>Onboard WiFi 4 (802.11n)</div>
 								<div><span>Storage:</span>8 GiB eMMC</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOAir-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOAir-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Small SBC with lots of features.</p>
@@ -415,7 +415,7 @@
 								<div><span>RAM:</span>512 MiB - 1 GiB DDR3</div>
 								<div><span>NET:</span>100 Mbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Small SBC with lots of features.</p>
@@ -467,7 +467,7 @@
 								<div><span>NET:</span>WiFi</div>
 								<div><span>Storage:</span>eMMC</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_Pinebook-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_Pinebook-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Pinebook is a phenomenal Linux laptop with exceptional build quality that rivals £300+ laptops. The unit is fitted with an exceptionally bright 1080p IPS screen, eMMC and onboard WiFi.</p>
@@ -483,7 +483,7 @@
 							<div class="project-info">
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_Hyper-V-x86_64-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_Hyper-V-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Hyper-V virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
@@ -498,7 +498,7 @@
 							<div class="project-info">
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Parallels virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
@@ -513,7 +513,7 @@
 							<div class="project-info">
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The UTM virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
@@ -528,7 +528,7 @@
 							<div class="project-info">
 								<div><span>ARCH:</span>x86_64</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Proxmox virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
@@ -546,7 +546,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidN2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidN2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Hardkernel's next generation "high-end" SBC is finally here! The fastest ARM SBC we have ever tested. Excellent performance and thermals at a reasonable price range.</p>
@@ -562,11 +562,11 @@
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bullseye.7z"><span>VMX appliance:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.7z"><span>VMX appliance:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This appliance can be used with <b>VMware Workstation Player/Pro</b> and <b>Fusion</b>.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_ESXi-x86_64-Bullseye.7z"><span>OVA appliance:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_ESXi-x86_64-Bookworm.7z"><span>OVA appliance:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>This appliance can be used with <b>VMware vSphere</b> and <b>ESXi</b>.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -583,7 +583,7 @@
 							<div class="project-info">
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The VirtualBox virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
@@ -601,7 +601,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPi4-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPi4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Compared to other RK3399 SBCs, this one is small sized, like the Raspberry Pi.</p>
@@ -618,7 +618,7 @@
 								<div><span>RAM:</span>256 MiB - 512 MiB DDR3</div>
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ZeroPi-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ZeroPi-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 						</div>
@@ -657,7 +657,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket (model S only), SDIO 3.0 (fast)</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ASUSTB-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ASUSTB-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Here come the giants "ASUS" with their first SBC on the market. It provides excellent performance as a SBC with its 1.8 GHz CPU and SDIO 3.0 for fast SD transfer rates. The S model contains an additional onboard eMMC module with write speeds of 70 MiB/s and read speeds of 150 MiB/s. A highly recommended SBC.</p>
@@ -692,7 +692,7 @@
 								<div><span>NET:</span>WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1Plus-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM1Plus-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Small SBC with lots of features.</p>
@@ -709,7 +709,7 @@
 								<div><span>RAM:</span>512 MiB DDR3</div>
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>An upgrade to the original Nano NEO, now features H5 64-bit CPU and Gbit LAN. Quite possibly the smallest (and cutest) SBC on the market. Great for headless/IoT/NAS/server/HiFi projects and showing old friends how small computers have become.</p>
@@ -726,7 +726,7 @@
 								<div><span>RAM:</span>2 GiB DDR3</div>
 								<div><span>NET:</span>Gbit Ethernet, WiFi</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK1Plus-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK1Plus-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A direct competitor to the RPi 3+. Features excellent and stable onboard WiFi, 64-bit CPU. A great all round board, utilizing the H5 ARM CPU. A good alternative to the RPi 3+, with increased performance at a similar price range.</p>
@@ -744,7 +744,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2Black-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO2Black-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A NEO2 upgrade with some additional features like eMMC and available with 1 GiB RAM</p>
@@ -762,7 +762,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4V2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4V2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>New build of the NanoPi M4 with DDR4 instead of DDR3 RAM.</p>
@@ -780,7 +780,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi*</div>
 								<div><span>Storage:</span>eMMC socket, PCIe (Model A only)</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEH64-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_PINEH64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The PINE H64 is available in two variants, Model A with larger PCB, PCIe slot and optional WiFi, and Model B with ROCK64-size PCB, without PCIe slot and fixed onboard WiFi.</p>
@@ -798,7 +798,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>eMMC socket, PCIe x4</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPro64-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPro64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The ROCK64's big brother is here! One of the fastest ARM SBC (RK3399) on the market today, with 2x1.8 GHz A72 cores and 4x1.4 GHz A53 cores. Onboard full size PCIe x4 with excellent throughput compliments a NAS/Server setup, and, endless opportunities. A great addition to your SBC lineup that provides next gen SBC performance. Bottom line: "it's a little chunky, but it ain't no monkey", we love it!</p>
@@ -816,7 +816,7 @@
 								<div><span>NET:</span>Gbit Ethernet, optional WiFi 5</div>
 								<div><span>Storage:</span>eMMC socket, PCIe x4, SATA 3.0</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64A-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64A-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>PINE64's next generation SBC based on the new Rockchip RK3566 SoC, which provides a lot of hardware features and connectors. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the SBC.</p>
@@ -834,7 +834,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi 5</div>
 								<div><span>Storage:</span>eMMC socket, M.2 slot</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64B-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_Quartz64B-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>PINE64's next generation SBC in credit card size, based on the new Rockchip RK3566 SoC, which provides a lot of hardware features and connectors. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the SBC.</p>
@@ -852,7 +852,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi 5</div>
 								<div><span>Storage:</span>eMMC socket, PCIe x1</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_SOQuartz-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_SOQuartz-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>PINE64's next generation compute module based on the new Rockchip RK3566 SoC, which provides a lot of hardware features. Note that the RK3566 is aimed to be a successor for RK3288 and RK3328, not for the flagship RK3399. So expect the raw CPU performance to be in the range of the ROCK64. The SoC however provides a lot more hardware features, connectors and slots exposed on the default baseboard.</p>
@@ -866,11 +866,11 @@
 						<div class="col-md-6 project-description">
 							<div class="project-info">
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bullseye.7z"><span>Direct write Image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bookworm.7z"><span>Direct write Image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>Choose this to write directly to the internal/root drive of the target system.
 								</div>
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bullseye_Installer.7z"><span>Installer Image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bookworm_Installer.7z"><span>Installer Image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>Choose this to write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -891,7 +891,7 @@
 								<div><span>USB:</span>3.0</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK64-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK64-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A welcomed evolution of the PINE64 is finally here. Reduced PCB size, low cost, USB 3.0, Gbit Ethernet and eMMC option. A worthy SBC for any server/NAS project.</p>
@@ -905,7 +905,7 @@
 						<div class="col-md-6 project-description">
 							<div class="project-info">
 								<div>
-									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-UEFI-x86_64-Bullseye_Installer.7z"><span>Installer Image:</span><i class="fa fa-download"></i><u>Download</u></a>
+									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-UEFI-x86_64-Bookworm_Installer.7z"><span>Installer Image:</span><i class="fa fa-download"></i><u>Download</u></a>
 									<br>Write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
@@ -941,7 +941,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>16 GiB eMMC, M.2 socket, PCIe x4</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPCT4-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPCT4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>FriendlyELEC's next generation SBC is finally here! One of the fastest ARM SBC (RK3399) on the market today, with 2x1.8 GHz A72 cores and 4x1.4 GHz A53 cores. Onboard M.2/PCIe x4 with excellent throughput compliments a NAS/Server setup. Bottom line, we love it!</p>
@@ -959,7 +959,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>Optional onboard SD NAND</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPiS-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCKPiS-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Little brother of the ROCK Pi 4, headless but with voice detection engine, for IoT and voice applications.</p>
@@ -977,7 +977,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>8 GiB eMMC</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOPlus2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEOPlus2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 						</div>
@@ -994,7 +994,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiM4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Little brother of the NanoPC T4 with same SoC (RK3399) performance but a few less features, like no onboard eMMC chip (but socket) and no M.2 socket. However the form factor is RPi-like which might suite certain use-cases.</p>
@@ -1012,7 +1012,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO4-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The smallest board of the M4/T4/NEO4 RK3399 family. One gets full RK3399 SoC power on a tiny form factor but pays this with only 1 GB RAM and the loss of the 3.5mm audio jack (HDMI audio only) compared to the M4.</p>
@@ -1030,7 +1030,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>USB:</span>3.0 Type A</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO3-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiNEO3-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A tiny headless SBC, comes in a cute white housing with fanless cooling. It has the ROCK64 SoC, so you know what you can expect, but it runs hot quickly inside there. Prepare to limit the maximum CPU frequency, apply a strict GPU governor or put the board into a new cool well ventilated home.</p>
@@ -1048,7 +1048,7 @@
 								<div><span>NET:</span>2x Gbit Ethernet</div>
 								<div><span>USB:</span>2.0 Type A</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR2S-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR2S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A headless dual-Ethernet SBC, useful as router setup or network bridge. It has the ROCK64 SoC, so you know what you can expect.</p>
@@ -1066,7 +1066,7 @@
 								<div><span>NET:</span>Gbit Ethernet, WiFi, Bluetooth</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK2-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiK2-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>A well featured SBC with the SoC that one might know from Odroid C2</p>
@@ -1084,7 +1084,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>eMMC socket</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC4-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OdroidC4-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Odroid C2 successor with modern upgraded components.</p>
@@ -1102,7 +1102,7 @@
 								<div><span>RAM:</span>1 GiB DDR3 - 4 GiB DDR4</div>
 								<div><span>NET:</span>2x Gbit Ethernet</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR4S-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR4S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>FriendlyELEC's RK3399 dual-Ethernet/router board. When using the optionally shipped metal case, the CPU temperature stays in moderate range without a fan, as long as you do not run long-term full-load processes. It is purely headless but has a serial/UART debug port, so if you use it for important services, we recommend to have a serial terminal or adapter cable available, to allow console access even in case of boot issues of failing network (no SSH).</p>
@@ -1121,7 +1121,7 @@
 								<div><span>NET:</span>2x/1x 2.5 Gbit + 1x 1 Gbit Ethernet</div>
 								<div><span>Storage:</span>8-32 GiB eMMC (optional on R5C)</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR5S-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR5S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>FriendlyELEC's latest RK3568 dual-2.5 Gbit Ethernet router board. When using the optionally shipped metal case, the CPU temperature stays in moderate range without a fan, as long as you do not run long-term full-load processes. Other than previous NanoPi router boards, the R5S has a HDMI port as well.</p>
@@ -1141,7 +1141,7 @@
 								<div><span>NET:</span>2x/1x 2.5 Gbit + 1x 1 Gbit Ethernet</div>
 								<div><span>Storage:</span>32 GiB eMMC (optional on R6C)</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR6S-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR6S-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>FriendlyELEC's new flagship mini router SBC, featuring the new Rockchip RK3588 SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>
@@ -1160,7 +1160,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>64/128 GiB eMMC</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_PinebookPro-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_PinebookPro-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The RK3399-based successor of the previous A64-based Pinebook.</p>
@@ -1179,7 +1179,7 @@
 								<div><span>NET:</span>1x GiB Ethernet + 1x 100 MiB Ethernet</div>
 								<div><span>Storage:</span>8 GiB eMMC</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR1-ARMv7-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_NanoPiR1-ARMv7-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The smallest dual-Ethernet SBC we currently support. This image should run on NanoPi R1S-H3 as well, which is pretty similar, just without eMMC and one USB port only.</p>
@@ -1199,7 +1199,7 @@
 								<div><span>NET:</span>Onboard WiFi 4/5 (802.11ac), Bluetooth 4/5</div>
 								<div><span>Storage:</span>8 - 128 GiB eMMC on 2 GiB RAM and up variants</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_RadxaZero-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_RadxaZero-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Radxa Zero features a quad core 64-bit ARM processor, 32bit LPDDR4, up to 4K@60 HDMI, 802.11ac WiFi, Bluetooth 5.0, USB 3.0, 40-pin GPIO header. Radxa Zero supports USB 2.0 OTG and power via one USB C port.
@@ -1222,7 +1222,7 @@
 								<div><span>NET:</span>Gbit Ethernet, optional Radxa Wireless Module</div>
 								<div><span>Storage:</span>microSD, eMMC and M.2 sockets</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK3A-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK3A-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Radxa's new mid-range SBC, featuring the new Rockchip RK3568 SoC with 4x Cortex A55 CPU @2.0 GHz</p>
@@ -1242,7 +1242,7 @@
 								<div><span>NET:</span>2.5 Gbit Ethernet, optional Radxa Wireless Module</div>
 								<div><span>Storage:</span>microSD and eMMC sockets</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK5B-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_ROCK5B-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Radxa's new flagship SBC, featuring the new Rockchip RK3588 SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>
@@ -1262,7 +1262,7 @@
 								<div><span>NET:</span>Gbit Ethernet</div>
 								<div><span>Storage:</span>microSD and eMMC sockets</div>
 								<br>
-								<div><a href="https://dietpi.com/downloads/images/DietPi_OrangePi5-ARMv8-Bullseye.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
+								<div><a href="https://dietpi.com/downloads/images/DietPi_OrangePi5-ARMv8-Bookworm.7z"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a></div>
 								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>Orange pi new flagship SBC, featuring the new Rockchip RK3588S SoC: A quad-core 4x Cortex-A76 @2.4 GHz + 4x Cortex A55 @1.8 GHz is making this the by far fastest SoC ever tested with DietPi.</p>


### PR DESCRIPTION
aside of NanoPi M2/M3/Fire3 and Sparky SBC, where we cannot provide Bookworm images due to ancient kernel which lacks needed features.