### PR TITLE
Download area: Added PC/VM linking to correct tabs in docu

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,7 +545,7 @@
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Hyper-V-x86_64-Bookworm.vhdx.xz"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_Hyper-V-x86_64-Bookworm.vhdx.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_Hyper-V-x86_64-Bookworm.vhdx.xz.asc"><u>Signature</u></a>)</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_8" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 							</div>
 							<p>The Hyper-V virtual machine is great for those occasions where SBC performance just isn't enough. Run one of these on any x86_64 PC/server and still get the same great DietPi features and experience.</p>
 							<p>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.</p>
@@ -561,7 +561,7 @@
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.tar.xz"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.tar.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_VMX-x86_64-Bookworm.tar.xz.asc"><u>Signature</u></a>)</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_6" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -580,7 +580,7 @@
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bookworm.tar.xz"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bookworm.tar.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_UTM-x86_64-Bookworm.tar.xz.asc"><u>Signature</u></a>)</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_7" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -599,7 +599,7 @@
 								<div><span>ARCH:</span>x86_64</div>
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bookworm.qcow2.xz"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bookworm.qcow2.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_Proxmox-x86_64-Bookworm.qcow2.xz.asc"><u>Signature</u></a>)</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_5" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -647,7 +647,7 @@
 									<a href="https://dietpi.com/downloads/images/DietPi_ESXi-x86_64-Bookworm.ova.xz"><span>OVA appliance:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_ESXi-x86_64-Bookworm.ova.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_ESXi-x86_64-Bookworm.ova.xz.asc"><u>Signature</u></a>)
 									<br>This appliance can be used with <b>VMware vSphere</b> and <b>ESXi</b>.
 								</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_3" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -666,7 +666,7 @@
 								<div><span>RAM:</span>1 GiB | Can be changed</div>
 								<br>
 								<div><a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bookworm.ova.xz"><span>Download Image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bookworm.ova.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_VirtualBox-x86_64-Bookworm.ova.xz.asc"><u>Signature</u></a>)</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_2" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -1044,7 +1044,7 @@
 									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bookworm_Installer.iso.xz"><span>Installer image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bookworm_Installer.iso.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_NativePC-BIOS-x86_64-Bookworm_Installer.iso.xz.asc"><u>Signature</u></a>)
 									<br>Choose this to write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_9" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.
@@ -1087,7 +1087,7 @@
 									<a href="https://dietpi.com/downloads/images/DietPi_NativePC-UEFI-x86_64-Bookworm_Installer.iso.xz"><span>Installer image:</span><i class="fa fa-download"></i><u>Download</u></a> (<a href="https://dietpi.com/downloads/images/DietPi_NativePC-UEFI-x86_64-Bookworm_Installer.iso.xz.sha256"><u>SHA256</u></a>) (<a href="https://dietpi.com/downloads/images/DietPi_NativePC-UEFI-x86_64-Bookworm_Installer.iso.xz.asc"><u>Signature</u></a>)
 									<br>Write to e.g. a USB stick to boot and install DietPi to an internal drive.
 								</div>
-								<div><a href="https://dietpi.com/docs/install/" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
+								<div><a href="https://dietpi.com/docs/install/#__tabbed_1_9" target="_blank" rel="noopener"><span>How to install / Details:</span><i class="fa fa-book"></i><u>View</u></a></div>
 								<div>
 									<span>Bullseye images:</span>
 									<br>We provide images based on the older Debian Bullseye release as well, as not all software in our catalogue is compatible with Debian Bookworm yet. All info about this can be found <a href="https://dietpi.com/blog/?p=3128" target="_blank" rel="noopener">here</a>.


### PR DESCRIPTION
The linking to the DietPi docu always led to the first tab of the installation description (SBC part). Now, the linking directs to the VMware, Proxmox,... tab.

See [DietPi Forum - [Native PC for UEFI always boot to Clonezilla](https://dietpi.com/forum/t/native-pc-for-uefi-always-boot-to-clonezilla/20624)](https://dietpi.com/forum/t/native-pc-for-uefi-always-boot-to-clonezilla/20624/10)